### PR TITLE
Updated Upgradable contracts based on Non-upgradable

### DIFF
--- a/contracts/contracts-upgradable/example/ExampleOFTUpgradeable.sol
+++ b/contracts/contracts-upgradable/example/ExampleOFTUpgradeable.sol
@@ -11,8 +11,10 @@ contract ExampleOFTUpgradeable is Initializable, OFTUpgradeable, Proxied {
     }
 
     function __ExampleOFTUpgradeable_init(string memory _name, string memory _symbol, uint _initialSupply, address _lzEndpoint) internal onlyInitializing {
-        __Ownable_init();
-        __OFTUpgradeable_init(_name, _symbol, _lzEndpoint);
+        __Context_init_unchained();
+        __Ownable_init_unchained();
+        __ERC20_init_unchained(_name, _symbol);
+        __LzAppUpgradeable_init_unchained(_lzEndpoint);
         __ExampleOFTUpgradeable_init_unchained(_name, _symbol, _initialSupply, _lzEndpoint);
     }
 

--- a/contracts/contracts-upgradable/example/ExampleONFT721Upgradeable.sol
+++ b/contracts/contracts-upgradable/example/ExampleONFT721Upgradeable.sol
@@ -11,8 +11,10 @@ contract ExampleONFT721Upgradeable is Initializable, ONFT721Upgradeable, Proxied
     }
 
     function __ONFT721UpgradeableMock_init(string memory _name, string memory _symbol, address _lzEndpoint) internal onlyInitializing {
-        __Ownable_init();
-        __ONFT721Upgradeable_init(_name, _symbol, _lzEndpoint);
+        __Context_init_unchained();
+        __Ownable_init_unchained();
+        __ERC721_init_unchained(_name, _symbol);
+        __LzAppUpgradeable_init_unchained(_lzEndpoint);
     }
 
     function __ONFT721UpgradeableMock_init_unchained(string memory _name, string memory _symbol, address _lzEndpoint) internal onlyInitializing {}

--- a/contracts/contracts-upgradable/lzApp/LzAppUpgradeable.sol
+++ b/contracts/contracts-upgradable/lzApp/LzAppUpgradeable.sol
@@ -6,19 +6,27 @@ import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "../interfaces/ILayerZeroReceiverUpgradeable.sol";
 import "../interfaces/ILayerZeroUserApplicationConfigUpgradeable.sol";
 import "../interfaces/ILayerZeroEndpointUpgradeable.sol";
+import "../../util/BytesLib.sol";
 
 /*
- * a generic LzReceiver implementation
+ * a generic Upgradeable LzReceiver implementation
  */
 abstract contract LzAppUpgradeable is Initializable, OwnableUpgradeable, ILayerZeroReceiverUpgradeable, ILayerZeroUserApplicationConfigUpgradeable {
+    using BytesLib for bytes;
+
     ILayerZeroEndpointUpgradeable public lzEndpoint;
     mapping(uint16 => bytes) public trustedRemoteLookup;
-    mapping(uint16 => mapping(uint => uint)) public minDstGasLookup;
+    mapping(uint16 => mapping(uint16 => uint)) public minDstGasLookup;
+    address public precrime;
 
-    event SetTrustedRemote(uint16 _srcChainId, bytes _srcAddress);
-    event SetMinDstGasLookup(uint16 _dstChainId, uint _type, uint _dstGasAmount);
+    event SetPrecrime(address precrime);
+    event SetTrustedRemote(uint16 _remoteChainId, bytes _path);
+    event SetTrustedRemoteAddress(uint16 _remoteChainId, bytes _remoteAddress);
+    event SetMinDstGas(uint16 _dstChainId, uint16 _type, uint _minDstGas);
 
     function __LzAppUpgradeable_init(address _endpoint) internal onlyInitializing {
+        __Context_init_unchained();
+        __Ownable_init_unchained();
         __LzAppUpgradeable_init_unchained(_endpoint);
     }
 
@@ -26,13 +34,13 @@ abstract contract LzAppUpgradeable is Initializable, OwnableUpgradeable, ILayerZ
         lzEndpoint = ILayerZeroEndpointUpgradeable(_endpoint);
     }
 
-    function lzReceive(uint16 _srcChainId, bytes memory _srcAddress, uint64 _nonce, bytes memory _payload) public virtual override {
+    function lzReceive(uint16 _srcChainId, bytes calldata _srcAddress, uint64 _nonce, bytes calldata _payload) public virtual override {
         // lzReceive must be called by the endpoint for security
-        require(_msgSender() == address(lzEndpoint), "LzApp: invalid endpoint caller");
+        require(_msgSender() == address(lzEndpoint), "LzAppUpgradeable: invalid endpoint caller");
 
         bytes memory trustedRemote = trustedRemoteLookup[_srcChainId];
         // if will still block the message pathway from (srcChainId, srcAddress). should not receive message from untrusted remote.
-        require(_srcAddress.length == trustedRemote.length && keccak256(_srcAddress) == keccak256(trustedRemote), "LzApp: invalid source sending contract");
+        require(_srcAddress.length == trustedRemote.length && trustedRemote.length > 0 && keccak256(_srcAddress) == keccak256(trustedRemote), "LzAppUpgradeable: invalid source sending contract");
 
         _blockingLzReceive(_srcChainId, _srcAddress, _nonce, _payload);
     }
@@ -40,20 +48,21 @@ abstract contract LzAppUpgradeable is Initializable, OwnableUpgradeable, ILayerZ
     // abstract function - the default behaviour of LayerZero is blocking. See: NonblockingLzApp if you dont need to enforce ordered messaging
     function _blockingLzReceive(uint16 _srcChainId, bytes memory _srcAddress, uint64 _nonce, bytes memory _payload) internal virtual;
 
-    function _lzSend(uint16 _dstChainId, bytes memory _payload, address payable _refundAddress, address _zroPaymentAddress, bytes memory _adapterParams) internal virtual {
+    function _lzSend(uint16 _dstChainId, bytes memory _payload, address payable _refundAddress, address _zroPaymentAddress, bytes memory _adapterParams, uint _nativeFee) internal virtual {
         bytes memory trustedRemote = trustedRemoteLookup[_dstChainId];
-        require(trustedRemote.length != 0, "LzApp: destination chain is not a trusted source");
-        lzEndpoint.send{value: msg.value}(_dstChainId, trustedRemote, _payload, _refundAddress, _zroPaymentAddress, _adapterParams);
+        require(trustedRemote.length != 0, "LzAppUpgradeable: destination chain is not a trusted source");
+        lzEndpoint.send{value: _nativeFee}(_dstChainId, trustedRemote, _payload, _refundAddress, _zroPaymentAddress, _adapterParams);
     }
 
-    function _checkGasLimit(uint16 _dstChainId, uint _type, bytes memory _adapterParams, uint _extraGas) internal view {
-        uint providedGasLimit = getGasLimit(_adapterParams);
+    function _checkGasLimit(uint16 _dstChainId, uint16 _type, bytes memory _adapterParams, uint _extraGas) internal view virtual {
+        uint providedGasLimit = _getGasLimit(_adapterParams);
         uint minGasLimit = minDstGasLookup[_dstChainId][_type] + _extraGas;
-        require(minGasLimit > 0, "LzApp: minGasLimit not set");
-        require(providedGasLimit >= minGasLimit, "LzApp: gas limit is too low");
+        require(minGasLimit > 0, "LzAppUpgradeable: minGasLimit not set");
+        require(providedGasLimit >= minGasLimit, "LzAppUpgradeable: gas limit is too low");
     }
 
-    function getGasLimit(bytes memory _adapterParams) public pure returns (uint gasLimit) {
+    function _getGasLimit(bytes memory _adapterParams) internal pure virtual returns (uint gasLimit) {
+        require(_adapterParams.length >= 34, "LzAppUpgradeable: invalid adapterParams");
         assembly {
             gasLimit := mload(add(_adapterParams, 34))
         }
@@ -81,16 +90,33 @@ abstract contract LzAppUpgradeable is Initializable, OwnableUpgradeable, ILayerZ
         lzEndpoint.forceResumeReceive(_srcChainId, _srcAddress);
     }
 
-    // allow owner to set it multiple times.
-    function setTrustedRemote(uint16 _srcChainId, bytes calldata _srcAddress) external onlyOwner {
-        trustedRemoteLookup[_srcChainId] = _srcAddress;
-        emit SetTrustedRemote(_srcChainId, _srcAddress);
+    // _path = abi.encodePacked(remoteAddress, localAddress)
+    // this function set the trusted path for the cross-chain communication
+    function setTrustedRemote(uint16 _srcChainId, bytes calldata _path) external onlyOwner {
+        trustedRemoteLookup[_srcChainId] = _path;
+        emit SetTrustedRemote(_srcChainId, _path);
     }
 
-    function setMinDstGasLookup(uint16 _dstChainId, uint _type, uint _dstGasAmount) external onlyOwner {
-        require(_dstGasAmount > 0, "LzApp: invalid _dstGasAmount");
-        minDstGasLookup[_dstChainId][_type] = _dstGasAmount;
-        emit SetMinDstGasLookup(_dstChainId, _type, _dstGasAmount);
+    function setTrustedRemoteAddress(uint16 _remoteChainId, bytes calldata _remoteAddress) external onlyOwner {
+        trustedRemoteLookup[_remoteChainId] = abi.encodePacked(_remoteAddress, address(this));
+        emit SetTrustedRemoteAddress(_remoteChainId, _remoteAddress);
+    }
+
+    function getTrustedRemoteAddress(uint16 _remoteChainId) external view returns (bytes memory) {
+        bytes memory path = trustedRemoteLookup[_remoteChainId];
+        require(path.length != 0, "LzAppUpgradeable: no trusted path record");
+        return path.slice(0, path.length - 20); // the last 20 bytes should be address(this)
+    }
+
+    function setPrecrime(address _precrime) external onlyOwner {
+        precrime = _precrime;
+        emit SetPrecrime(_precrime);
+    }
+
+    function setMinDstGas(uint16 _dstChainId, uint16 _packetType, uint _minGas) external onlyOwner {
+        require(_minGas > 0, "LzAppUpgradeable: invalid minGas");
+        minDstGasLookup[_dstChainId][_packetType] = _minGas;
+        emit SetMinDstGas(_dstChainId, _packetType, _minGas);
     }
 
     //--------------------------- VIEW FUNCTION ----------------------------------------

--- a/contracts/contracts-upgradable/lzApp/NonblockingLzAppUpgradeable.sol
+++ b/contracts/contracts-upgradable/lzApp/NonblockingLzAppUpgradeable.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.2;
 
 import "./LzAppUpgradeable.sol";
+import "../../util/ExcessivelySafeCall.sol";
 
 /*
  * the default LayerZero messaging behaviour is blocking, i.e. any failed message will block the channel
@@ -10,48 +11,49 @@ import "./LzAppUpgradeable.sol";
  * NOTE: if the srcAddress is not configured properly, it will still block the message pathway from (srcChainId, srcAddress)
  */
 abstract contract NonblockingLzAppUpgradeable is Initializable, LzAppUpgradeable {
+    using ExcessivelySafeCall for address;
+
     function __NonblockingLzAppUpgradeable_init(address _endpoint) internal onlyInitializing {
-        __NonblockingLzAppUpgradeable_init_unchained(_endpoint);
+        __LzAppUpgradeable_init_unchained(_endpoint);
     }
 
     function __NonblockingLzAppUpgradeable_init_unchained(address _endpoint) internal onlyInitializing {
-        __LzAppUpgradeable_init_unchained(_endpoint);
     }
 
     mapping(uint16 => mapping(bytes => mapping(uint64 => bytes32))) public failedMessages;
 
-    event MessageFailed(uint16 _srcChainId, bytes _srcAddress, uint64 _nonce, bytes _payload);
+    event MessageFailed(uint16 _srcChainId, bytes _srcAddress, uint64 _nonce, bytes _payload, bytes _reason);
+    event RetryMessageSuccess(uint16 _srcChainId, bytes _srcAddress, uint64 _nonce, bytes32 _payloadHash);
 
     // overriding the virtual function in LzReceiver
     function _blockingLzReceive(uint16 _srcChainId, bytes memory _srcAddress, uint64 _nonce, bytes memory _payload) internal virtual override {
-        // try-catch all errors/exceptions
-        try this.nonblockingLzReceive(_srcChainId, _srcAddress, _nonce, _payload) {
-            // do nothing
-        } catch {
-            // error / exception
+        (bool success, bytes memory reason) = address(this).excessivelySafeCall(gasleft(), 150, abi.encodeWithSelector(this.nonblockingLzReceive.selector, _srcChainId, _srcAddress, _nonce, _payload));
+        
+        if (!success) {
             failedMessages[_srcChainId][_srcAddress][_nonce] = keccak256(_payload);
-            emit MessageFailed(_srcChainId, _srcAddress, _nonce, _payload);
+            emit MessageFailed(_srcChainId, _srcAddress, _nonce, _payload, reason);
         }
     }
 
-    function nonblockingLzReceive(uint16 _srcChainId, bytes memory _srcAddress, uint64 _nonce, bytes memory _payload) public virtual {
+    function nonblockingLzReceive(uint16 _srcChainId, bytes calldata _srcAddress, uint64 _nonce, bytes calldata _payload) public virtual {
         // only internal transaction
-        require(_msgSender() == address(this), "NonblockingLzApp: caller must be LzApp");
+        require(_msgSender() == address(this), "NonblockingLzAppUpgradeable: caller must be LzAppUpgradeable");
         _nonblockingLzReceive(_srcChainId, _srcAddress, _nonce, _payload);
     }
 
     //@notice override this function
     function _nonblockingLzReceive(uint16 _srcChainId, bytes memory _srcAddress, uint64 _nonce, bytes memory _payload) internal virtual;
 
-    function retryMessage(uint16 _srcChainId, bytes memory _srcAddress, uint64 _nonce, bytes memory _payload) public payable virtual {
+    function retryMessage(uint16 _srcChainId, bytes calldata _srcAddress, uint64 _nonce, bytes calldata _payload) public payable virtual {
         // assert there is message to retry
         bytes32 payloadHash = failedMessages[_srcChainId][_srcAddress][_nonce];
-        require(payloadHash != bytes32(0), "NonblockingLzApp: no stored message");
-        require(keccak256(_payload) == payloadHash, "NonblockingLzApp: invalid payload");
+        require(payloadHash != bytes32(0), "NonblockingLzAppUpgradeable: no stored message");
+        require(keccak256(_payload) == payloadHash, "NonblockingLzAppUpgradeable: invalid payload");
         // clear the stored message
         failedMessages[_srcChainId][_srcAddress][_nonce] = bytes32(0);
         // execute the message. revert if it fails again
         _nonblockingLzReceive(_srcChainId, _srcAddress, _nonce, _payload);
+        emit RetryMessageSuccess(_srcChainId, _srcAddress, _nonce, payloadHash);
     }
 
     /**

--- a/contracts/contracts-upgradable/token/OFT/IOFTCoreUpgradeable.sol
+++ b/contracts/contracts-upgradable/token/OFT/IOFTCoreUpgradeable.sol
@@ -36,14 +36,14 @@ interface IOFTCoreUpgradeable is IERC165Upgradeable {
     function circulatingSupply() external view returns (uint);
 
     /**
-     * @dev Emitted when `_amount` tokens are moved from the `_sender` to (`_dstChainId`, `_toAddress`)
-     * `_nonce` is the outbound nonce
+     * @dev Emitted when `_amount` tokens are moved from the `_from` to (`_dstChainId`, `_toAddress`)
      */
-    event SendToChain(address indexed _sender, uint16 indexed _dstChainId, bytes indexed _toAddress, uint _amount, uint64 _nonce);
+    event SendToChain(uint16 indexed _dstChainId, address indexed _from, bytes indexed _toAddress, uint _amount);
 
     /**
      * @dev Emitted when `_amount` tokens are received from `_srcChainId` into the `_toAddress` on the local chain.
-     * `_nonce` is the inbound nonce.
      */
-    event ReceiveFromChain(uint16 indexed _srcChainId, bytes indexed _srcAddress, address indexed _toAddress, uint _amount, uint64 _nonce);
+    event ReceiveFromChain(uint16 indexed _srcChainId, bytes _fromAddress, address indexed _toAddress, uint _amount);
+
+    event SetUseCustomAdapterParams(bool _useCustomAdapterParams);
 }

--- a/contracts/contracts-upgradable/token/OFT/OFTCoreUpgradeable.sol
+++ b/contracts/contracts-upgradable/token/OFT/OFTCoreUpgradeable.sol
@@ -7,65 +7,82 @@ import "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeabl
 import "../../lzApp/NonblockingLzAppUpgradeable.sol";
 
 abstract contract OFTCoreUpgradeable is Initializable, NonblockingLzAppUpgradeable, ERC165Upgradeable, IOFTCoreUpgradeable {
+    using BytesLib for bytes;
+
     uint public constant NO_EXTRA_GAS = 0;
-    uint public constant FUNCTION_TYPE_SEND = 1;
+
+    // packet type
+    uint16 public constant PT_SEND = 0;
+
     bool public useCustomAdapterParams;
 
-    event SetUseCustomAdapterParams(bool _useCustomAdapterParams);
-
     function __OFTCoreUpgradeable_init(address _endpoint) internal onlyInitializing {
-        __OFTCoreUpgradeable_init_unchained(_endpoint);
+        __Context_init_unchained();
+        __Ownable_init_unchained();
+        __LzAppUpgradeable_init_unchained(_endpoint);
     }
 
     function __OFTCoreUpgradeable_init_unchained(address _endpoint) internal onlyInitializing {
-        __NonblockingLzAppUpgradeable_init_unchained(_endpoint);
     }
 
     function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165Upgradeable, IERC165Upgradeable) returns (bool) {
         return interfaceId == type(IOFTCoreUpgradeable).interfaceId || super.supportsInterface(interfaceId);
     }
 
-    function estimateSendFee(uint16 _dstChainId, bytes memory _toAddress, uint _amount, bool _useZro, bytes memory _adapterParams) public view virtual override returns (uint nativeFee, uint zroFee) {
-        // mock the payload for send()
-        bytes memory payload = abi.encode(_toAddress, _amount);
+    function estimateSendFee(uint16 _dstChainId, bytes calldata _toAddress, uint _amount, bool _useZro, bytes calldata _adapterParams) public view virtual override returns (uint nativeFee, uint zroFee) {
+        // mock the payload for sendFrom()
+        bytes memory payload = abi.encode(PT_SEND, abi.encodePacked(msg.sender), _toAddress, _amount);
         return lzEndpoint.estimateFees(_dstChainId, address(this), payload, _useZro, _adapterParams);
     }
 
-    function sendFrom(address _from, uint16 _dstChainId, bytes memory _toAddress, uint _amount, address payable _refundAddress, address _zroPaymentAddress, bytes memory _adapterParams) public payable virtual override {
+    function sendFrom(address _from, uint16 _dstChainId, bytes calldata _toAddress, uint _amount, address payable _refundAddress, address _zroPaymentAddress, bytes calldata _adapterParams) public payable virtual override {
         _send(_from, _dstChainId, _toAddress, _amount, _refundAddress, _zroPaymentAddress, _adapterParams);
     }
 
+    function setUseCustomAdapterParams(bool _useCustomAdapterParams) public virtual onlyOwner {
+        useCustomAdapterParams = _useCustomAdapterParams;
+        emit SetUseCustomAdapterParams(_useCustomAdapterParams);
+    }
+
     function _nonblockingLzReceive(uint16 _srcChainId, bytes memory _srcAddress, uint64 _nonce, bytes memory _payload) internal virtual override {
-        // decode and load the toAddress
-        (bytes memory toAddressBytes, uint amount) = abi.decode(_payload, (bytes, uint));
-        address toAddress;
+        uint16 packetType;
         assembly {
-            toAddress := mload(add(toAddressBytes, 20))
+            packetType := mload(add(_payload, 32))
         }
 
-        _creditTo(_srcChainId, toAddress, amount);
-
-        emit ReceiveFromChain(_srcChainId, _srcAddress, toAddress, amount, _nonce);
+        if (packetType == PT_SEND) {
+            _sendAck(_srcChainId, _srcAddress, _nonce, _payload);
+        } else {
+            revert("OFTCore: unknown packet type");
+        }
     }
 
     function _send(address _from, uint16 _dstChainId, bytes memory _toAddress, uint _amount, address payable _refundAddress, address _zroPaymentAddress, bytes memory _adapterParams) internal virtual {
+        _checkAdapterParams(_dstChainId, PT_SEND, _adapterParams, NO_EXTRA_GAS);
+
         _debitFrom(_from, _dstChainId, _toAddress, _amount);
 
-        bytes memory payload = abi.encode(_toAddress, _amount);
-        if (useCustomAdapterParams) {
-            _checkGasLimit(_dstChainId, FUNCTION_TYPE_SEND, _adapterParams, NO_EXTRA_GAS);
-        } else {
-            require(_adapterParams.length == 0, "LzApp: _adapterParams must be empty.");
-        }
-        _lzSend(_dstChainId, payload, _refundAddress, _zroPaymentAddress, _adapterParams);
+        bytes memory lzPayload = abi.encode(PT_SEND, abi.encodePacked(_from), _toAddress, _amount);
+        _lzSend(_dstChainId, lzPayload, _refundAddress, _zroPaymentAddress, _adapterParams, msg.value);
 
-        uint64 nonce = lzEndpoint.getOutboundNonce(_dstChainId, address(this));
-        emit SendToChain(_from, _dstChainId, _toAddress, _amount, nonce);
+        emit SendToChain(_dstChainId, _from, _toAddress, _amount);
     }
 
-    function setUseCustomAdapterParams(bool _useCustomAdapterParams) external onlyOwner {
-        useCustomAdapterParams = _useCustomAdapterParams;
-        emit SetUseCustomAdapterParams(_useCustomAdapterParams);
+    function _sendAck(uint16 _srcChainId, bytes memory, uint64, bytes memory _payload) internal virtual {
+        (, bytes memory from, bytes memory toAddressBytes, uint amount) = abi.decode(_payload, (uint16, bytes, bytes, uint));
+
+        address to = toAddressBytes.toAddress(0);
+
+        _creditTo(_srcChainId, to, amount);
+        emit ReceiveFromChain(_srcChainId, from, to, amount);
+    }
+
+    function _checkAdapterParams(uint16 _dstChainId, uint16 _pkType, bytes memory _adapterParams, uint _extraGas) internal virtual {
+        if (useCustomAdapterParams) {
+            _checkGasLimit(_dstChainId, _pkType, _adapterParams, _extraGas);
+        } else {
+            require(_adapterParams.length == 0, "OFTCore: _adapterParams must be empty.");
+        }
     }
 
     function _debitFrom(address _from, uint16 _dstChainId, bytes memory _toAddress, uint _amount) internal virtual;

--- a/contracts/contracts-upgradable/token/OFT/OFTUpgradeable.sol
+++ b/contracts/contracts-upgradable/token/OFT/OFTUpgradeable.sol
@@ -9,10 +9,12 @@ import "./OFTCoreUpgradeable.sol";
 import "./IOFTUpgradeable.sol";
 
 // override decimal() function is needed
-contract OFTUpgradeable is Initializable, OFTCoreUpgradeable, ERC20Upgradeable, IOFTUpgradeable {
+contract OFTUpgradeable is OFTCoreUpgradeable, ERC20Upgradeable, IOFTUpgradeable {
     function __OFTUpgradeable_init(string memory _name, string memory _symbol, address _lzEndpoint) internal onlyInitializing {
+        __Context_init_unchained();
+        __Ownable_init_unchained();
         __ERC20_init_unchained(_name, _symbol);
-        __OFTCoreUpgradeable_init_unchained(_lzEndpoint);
+        __LzAppUpgradeable_init_unchained(_lzEndpoint);
     }
 
     function __OFTUpgradeable_init_unchained(string memory _name, string memory _symbol, address _lzEndpoint) internal onlyInitializing {}

--- a/contracts/contracts-upgradable/token/ONFT721/IONFT721CoreUpgradeable.sol
+++ b/contracts/contracts-upgradable/token/ONFT721/IONFT721CoreUpgradeable.sol
@@ -28,12 +28,11 @@ interface IONFT721CoreUpgradeable is IERC165Upgradeable {
 
     /**
      * @dev Emitted when `_tokenId` are moved from the `_sender` to (`_dstChainId`, `_toAddress`)
-     * `_nonce` is the outbound nonce from
      */
-    event SendToChain(address indexed _sender, uint16 indexed _dstChainId, bytes indexed _toAddress, uint _tokenId, uint64 _nonce);
+    event SendToChain(uint16 indexed _dstChainId, address indexed _from, bytes indexed _toAddress, uint _tokenId);
 
     /**
-     * @dev Emitted when `_tokenId` are sent from `_srcChainId` to the `_toAddress` at this chain. `_nonce` is the inbound nonce.
+     * @dev Emitted when `_tokenId` are sent from `_srcChainId` to the `_toAddress` at this chain.
      */
-    event ReceiveFromChain(uint16 indexed _srcChainId, bytes indexed _srcAddress, address indexed _toAddress, uint _tokenId, uint64 _nonce);
+    event ReceiveFromChain(uint16 indexed _srcChainId, bytes indexed _srcAddress, address indexed _toAddress, uint _tokenId);
 }

--- a/contracts/contracts-upgradable/token/ONFT721/IONFT721Upgradeable.sol
+++ b/contracts/contracts-upgradable/token/ONFT721/IONFT721Upgradeable.sol
@@ -9,5 +9,4 @@ import "./IONFT721CoreUpgradeable.sol";
  * @dev Interface of the ONFT standard
  */
 interface IONFT721Upgradeable is IONFT721CoreUpgradeable, IERC721Upgradeable {
-
 }

--- a/contracts/contracts-upgradable/token/ONFT721/ONFT721Upgradeable.sol
+++ b/contracts/contracts-upgradable/token/ONFT721/ONFT721Upgradeable.sol
@@ -12,8 +12,10 @@ import "./IONFT721Upgradeable.sol";
 // must implement your own minting logic in child classes
 contract ONFT721Upgradeable is Initializable, ONFT721CoreUpgradeable, ERC721Upgradeable, IONFT721Upgradeable {
     function __ONFT721Upgradeable_init(string memory _name, string memory _symbol, address _lzEndpoint) internal onlyInitializing {
+        __Context_init_unchained();
+        __Ownable_init_unchained();
         __ERC721_init_unchained(_name, _symbol);
-        __ONFT721CoreUpgradeable_init_unchained(_lzEndpoint);
+        __LzAppUpgradeable_init_unchained(_lzEndpoint);
     }
 
     function __ONFT721Upgradeable_init_unchained(string memory _name, string memory _symbol, address _lzEndpoint) internal onlyInitializing {}

--- a/contracts/token/oft/IOFTCore.sol
+++ b/contracts/token/oft/IOFTCore.sol
@@ -37,16 +37,14 @@ interface IOFTCore is IERC165 {
     function circulatingSupply() external view returns (uint);
 
     /**
-     * @dev Emitted when `_amount` tokens are moved from the `_sender` to (`_dstChainId`, `_toAddress`)
-     * `_nonce` is the outbound nonce
+     * @dev Emitted when `_amount` tokens are moved from the `_from` to (`_dstChainId`, `_toAddress`)
      */
     event SendToChain(uint16 indexed _dstChainId, address indexed _from, bytes indexed _toAddress, uint _amount);
 
     /**
      * @dev Emitted when `_amount` tokens are received from `_srcChainId` into the `_toAddress` on the local chain.
-     * `_nonce` is the inbound nonce.
      */
-    event ReceiveFromChain(uint16 indexed _srcChainId, bytes _fromAddress, address indexed _to, uint _amount);
+    event ReceiveFromChain(uint16 indexed _srcChainId, bytes _fromAddress, address indexed _toAddress, uint _amount);
 
     event SetUseCustomAdapterParams(bool _useCustomAdapterParams);
 }

--- a/contracts/token/onft/IONFT721Core.sol
+++ b/contracts/token/onft/IONFT721Core.sol
@@ -28,12 +28,11 @@ interface IONFT721Core is IERC165 {
 
     /**
      * @dev Emitted when `_tokenId` are moved from the `_sender` to (`_dstChainId`, `_toAddress`)
-     * `_nonce` is the outbound nonce from
      */
     event SendToChain(uint16 indexed _dstChainId, address indexed _from, bytes indexed _toAddress, uint _tokenId);
 
     /**
-     * @dev Emitted when `_tokenId` are sent from `_srcChainId` to the `_toAddress` at this chain. `_nonce` is the inbound nonce.
+     * @dev Emitted when `_tokenId` are sent from `_srcChainId` to the `_toAddress` at this chain.
      */
     event ReceiveFromChain(uint16 indexed _srcChainId, bytes indexed _srcAddress, address indexed _toAddress, uint _tokenId);
 }

--- a/test/contracts-upgradeable/oft/OFTUpgradeable.test.js
+++ b/test/contracts-upgradeable/oft/OFTUpgradeable.test.js
@@ -31,7 +31,7 @@ describe("OFTUpgradeable: ", function () {
         lzEndpointDstMock.setDestLzEndpoint(OFTSrc.address, lzEndpointSrcMock.address)
 
         //set destination min gas
-        await OFTSrc.setMinDstGasLookup(chainIdDst, parseInt(await OFTSrc.FUNCTION_TYPE_SEND()), 220000)
+        await OFTSrc.setMinDstGas(chainIdDst, parseInt(await OFTSrc.PT_SEND()), 220000)
         await OFTSrc.setUseCustomAdapterParams(true)
 
         // set each contracts source address so it can send to each other
@@ -129,7 +129,7 @@ describe("OFTUpgradeable: ", function () {
             // balance before transfer is 0
             expect(await OFTDst.balanceOf(deployer.address)).to.be.equal(0)
 
-            const payload = ethers.utils.defaultAbiCoder.encode(["bytes", "uint256"], [deployer.address, sendQty])
+            const payload = ethers.utils.defaultAbiCoder.encode(["uint16", "bytes", "bytes", "uint256"], [parseInt(await OFTSrc.PT_SEND()), deployer.address, deployer.address, sendQty])
             await expect(lzEndpointDstMock.retryPayload(chainIdSrc, srcPath, payload)).to.emit(lzEndpointDstMock, "PayloadCleared")
 
             // balance after transfer is sendQty


### PR DESCRIPTION
1. Updated upgradable contracts based on non-upgradable. To review see the difference between upgradable and non-upgradable contracts (e.g. LzApp and LzAppUpgradeable)
2. Refactored usage of the `*_init` and `*_init_unchained` based on the audit and OpenZeppelin examples
3. Fixed a failed test. 