### PR TITLE
Support Core testnet

### DIFF
--- a/constants/chainIds.json
+++ b/constants/chainIds.json
@@ -13,5 +13,6 @@
   "mumbai":           10109,
   "arbitrum-goerli":  10143,
   "optimism-goerli":  10132,
-  "fantom-testnet":   10112
+  "fantom-testnet":   10112,
+  "core-testnet":     10153
 }

--- a/constants/layerzeroEndpoints.json
+++ b/constants/layerzeroEndpoints.json
@@ -13,5 +13,6 @@
   "mumbai": "0xf69186dfBa60DdB133E91E9A4B5673624293d8F8",
   "arbitrum-goerli": "0x6aB5Ae6822647046626e83ee6dB8187151E1d5ab",
   "optimism-goerli": "0xae92d5aD7583AD66E49A0c67BAd18F6ba52dDDc1",
-  "fantom-testnet": "0x7dcAD72640F835B0FA36EFD3D6d3ec902C7E5acf"
+  "fantom-testnet": "0x7dcAD72640F835B0FA36EFD3D6d3ec902C7E5acf",
+  "core-testnet": "0xae92d5aD7583AD66E49A0c67BAd18F6ba52dDDc1"
 }

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -160,6 +160,11 @@ module.exports = {
       url: `https://rpc.testnet.fantom.network/`,
       chainId: 4002,
       accounts: accounts(),
+    },
+    'core-testnet': {
+      url: `https://rpc.test.btcs.network`,
+      chainId: 1115,
+      accounts: accounts(),
     }
   }
 };


### PR DESCRIPTION
Adds config variables from [LayerZero docs](https://layerzero.gitbook.io/docs/technical-reference/testnet/testnet-addresses) and [Core docs](https://docs.coredao.org/developer/user-guides/user-guide-for-core-testnet#add-core-testnet) in order to support core testnet. Tested and working with OmniCounter's [Increment Counter](https://goerli.etherscan.io/tx/0xfa40db95ff3be83467e61a1075e4e4c386ddc030527af14e0520b37b18e44633).