### PR TITLE
Fix a bug in PingPong.sol

### DIFF
--- a/contracts/examples/PingPong.sol
+++ b/contracts/examples/PingPong.sol
@@ -58,7 +58,7 @@ contract PingPong is NonblockingLzApp, Pausable {
             payable(this), // (msg.sender will be this contract) refund address (LayerZero will refund any extra gas back to caller of send()
             address(0x0), // future param, unused for this example
             adapterParams, // v1 adapterParams, specify custom destination gas qty
-            msg.value
+            address(this).balance
         );
     }
 


### PR DESCRIPTION
Since "receivePayload" function in EP is not payable, "ping" called internally should use address(this).balance instead of msg.value