### PR TITLE
upgradeable contract updates

### DIFF
--- a/contracts/contracts-upgradable/example/ExampleOFTUpgradeable.sol
+++ b/contracts/contracts-upgradable/example/ExampleOFTUpgradeable.sol
@@ -7,23 +7,7 @@ import "../token/oft/OFTUpgradeable.sol";
 
 contract ExampleOFTUpgradeable is Initializable, OFTUpgradeable, Proxied {
     function initialize(string memory _name, string memory _symbol, uint _initialSupply, address _lzEndpoint) public initializer {
-        __ExampleOFTUpgradeable_init(_name, _symbol, _initialSupply, _lzEndpoint);
-    }
-
-    function __ExampleOFTUpgradeable_init(string memory _name, string memory _symbol, uint _initialSupply, address _lzEndpoint) internal onlyInitializing {
-        __Ownable_init();
         __OFTUpgradeable_init(_name, _symbol, _lzEndpoint);
-        __ExampleOFTUpgradeable_init_unchained(_name, _symbol, _initialSupply, _lzEndpoint);
-    }
-
-    function __ExampleOFTUpgradeable_init_unchained(string memory, string memory, uint _initialSupply, address) internal onlyInitializing {
         _mint(_msgSender(), _initialSupply);
     }
-
-    /**
-     * @dev This empty reserved space is put in place to allow future versions to add new
-     * variables without shifting down storage in the inheritance chain.
-     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
-     */
-    uint[50] private __gap;
 }

--- a/contracts/contracts-upgradable/example/ExampleONFT1155Upgradeable.sol
+++ b/contracts/contracts-upgradable/example/ExampleONFT1155Upgradeable.sol
@@ -7,33 +7,17 @@ import "../token/onft/1155/ONFT1155Upgradable.sol";
 
 contract ExampleONFT1155Upgradeable is Initializable, ONFT1155Upgradeable, Proxied {
     function initialize(string memory _uri, address _lzEndpoint, uint _amount) public initializer {
-        __ExampleONFT1155Upgradeable_init(_uri, _lzEndpoint, _amount);
-    }
-
-    function __ExampleONFT1155Upgradeable_init(string memory _uri, address _lzEndpoint, uint _amount) internal onlyInitializing {
-        __Ownable_init();
         __ONFT1155Upgradeable_init(_uri, _lzEndpoint);
-        __ExampleONFT1155Upgradeable_init_unchained(_amount);
-    }
-
-    function __ExampleONFT1155Upgradeable_init_unchained(uint _amount) internal onlyInitializing {
         if(_amount > 0) {
             _mint(_msgSender(), 1, _amount, "");
         }
     }
 
-    function mintBatch(address _to, uint256[] memory _ids, uint256[] memory _amounts) external payable {
+    function mintBatch(address _to, uint256[] memory _ids, uint256[] memory _amounts) external {
         _mintBatch(_to, _ids, _amounts, "");
     }
 
-    function mint(address _to, uint256 _id, uint256 _amount) external payable {
+    function mint(address _to, uint256 _id, uint256 _amount) external {
         _mint(_to, _id, _amount, "");
     }
-
-    /**
-     * @dev This empty reserved space is put in place to allow future versions to add new
-     * variables without shifting down storage in the inheritance chain.
-     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
-     */
-    uint[50] private __gap;
 }

--- a/contracts/contracts-upgradable/example/ExampleONFT721Upgradeable.sol
+++ b/contracts/contracts-upgradable/example/ExampleONFT721Upgradeable.sol
@@ -7,24 +7,10 @@ import "../token/onft/721/ONFT721Upgradeable.sol";
 
 contract ExampleONFT721Upgradeable is Initializable, ONFT721Upgradeable, Proxied {
     function initialize(string memory _name, string memory _symbol, uint256 _minGasToTransfer, address _lzEndpoint) public initializer {
-        __ExampleONFT721Upgradeable_init(_name, _symbol, _minGasToTransfer, _lzEndpoint);
-    }
-
-    function __ExampleONFT721Upgradeable_init(string memory _name, string memory _symbol, uint256 _minGasToTransfer, address _lzEndpoint) internal onlyInitializing {
-        __Ownable_init();
         __ONFT721Upgradeable_init(_name, _symbol, _minGasToTransfer, _lzEndpoint);
     }
 
-    function __ExampleONFT721Upgradeable_init_unchained() internal onlyInitializing {}
-
-    function mint(address _tokenOwner, uint _newId) external payable {
+    function mint(address _tokenOwner, uint _newId) external {
         _safeMint(_tokenOwner, _newId);
     }
-
-    /**
-     * @dev This empty reserved space is put in place to allow future versions to add new
-     * variables without shifting down storage in the inheritance chain.
-     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
-     */
-    uint[50] private __gap;
 }

--- a/contracts/contracts-upgradable/lzApp/LzAppUpgradeable.sol
+++ b/contracts/contracts-upgradable/lzApp/LzAppUpgradeable.sol
@@ -147,5 +147,5 @@ abstract contract LzAppUpgradeable is Initializable, OwnableUpgradeable, ILayerZ
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint[44] private __gap;
+    uint[45] private __gap;
 }

--- a/contracts/contracts-upgradable/lzApp/NonblockingLzAppUpgradeable.sol
+++ b/contracts/contracts-upgradable/lzApp/NonblockingLzAppUpgradeable.sol
@@ -14,8 +14,8 @@ abstract contract NonblockingLzAppUpgradeable is Initializable, LzAppUpgradeable
     using ExcessivelySafeCall for address;
 
     function __NonblockingLzAppUpgradeable_init(address _endpoint) internal onlyInitializing {
+        __Ownable_init_unchained();
         __LzAppUpgradeable_init_unchained(_endpoint);
-        __NonblockingLzAppUpgradeable_init_unchained(_endpoint);
     }
 
     function __NonblockingLzAppUpgradeable_init_unchained(address _endpoint) internal onlyInitializing {}

--- a/contracts/contracts-upgradable/token/oft/OFTCoreUpgradeable.sol
+++ b/contracts/contracts-upgradable/token/oft/OFTCoreUpgradeable.sol
@@ -17,6 +17,7 @@ abstract contract OFTCoreUpgradeable is Initializable, NonblockingLzAppUpgradeab
     bool public useCustomAdapterParams;
 
     function __OFTCoreUpgradeable_init(address _lzEndpoint) internal onlyInitializing {
+        __Ownable_init_unchained();
         __LzAppUpgradeable_init_unchained(_lzEndpoint);
     }
 
@@ -27,7 +28,7 @@ abstract contract OFTCoreUpgradeable is Initializable, NonblockingLzAppUpgradeab
     }
 
     function estimateSendFee(uint16 _dstChainId, bytes calldata _toAddress, uint _amount, bool _useZro, bytes calldata _adapterParams) public view virtual override returns (uint nativeFee, uint zroFee) {
-        // mock the payload for send()
+        // mock the payload for sendFrom()
         bytes memory payload = abi.encode(PT_SEND, _toAddress, _amount);
         return lzEndpoint.estimateFees(_dstChainId, address(this), payload, _useZro, _adapterParams);
     }
@@ -91,5 +92,5 @@ abstract contract OFTCoreUpgradeable is Initializable, NonblockingLzAppUpgradeab
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint[48] private __gap;
+    uint[49] private __gap;
 }

--- a/contracts/contracts-upgradable/token/oft/OFTUpgradeable.sol
+++ b/contracts/contracts-upgradable/token/oft/OFTUpgradeable.sol
@@ -3,15 +3,15 @@
 pragma solidity ^0.8.2;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/introspection/IERC165Upgradeable.sol";
-import "./OFTCoreUpgradeable.sol";
 import "./IOFTUpgradeable.sol";
+import "./OFTCoreUpgradeable.sol";
 
 // override decimal() function is needed
 contract OFTUpgradeable is Initializable, OFTCoreUpgradeable, ERC20Upgradeable, IOFTUpgradeable {
     function __OFTUpgradeable_init(string memory _name, string memory _symbol, address _lzEndpoint) internal onlyInitializing {
         __ERC20_init_unchained(_name, _symbol);
+        __Ownable_init_unchained();
         __LzAppUpgradeable_init_unchained(_lzEndpoint);
     }
 
@@ -29,7 +29,7 @@ contract OFTUpgradeable is Initializable, OFTCoreUpgradeable, ERC20Upgradeable, 
         return totalSupply();
     }
 
-    function _debitFrom(address _from, uint16, bytes memory, uint _amount) internal virtual override returns (uint) {
+    function _debitFrom(address _from, uint16, bytes memory, uint _amount) internal virtual override returns(uint) {
         address spender = _msgSender();
         if (_from != spender) _spendAllowance(_from, spender, _amount);
         _burn(_from, _amount);

--- a/contracts/contracts-upgradable/token/onft/1155/ONFT1155CoreUpgradeable.sol
+++ b/contracts/contracts-upgradable/token/onft/1155/ONFT1155CoreUpgradeable.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.0;
 
+import "./IONFT1155CoreUpgradeable.sol";
 import "../../../lzApp/NonblockingLzAppUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
-import "./IONFT1155CoreUpgradeable.sol";
 
 abstract contract ONFT1155CoreUpgradeable is Initializable, NonblockingLzAppUpgradeable, ERC165Upgradeable, IONFT1155CoreUpgradeable {
     uint public constant NO_EXTRA_GAS = 0;
@@ -15,6 +15,7 @@ abstract contract ONFT1155CoreUpgradeable is Initializable, NonblockingLzAppUpgr
     event SetUseCustomAdapterParams(bool _useCustomAdapterParams);
 
     function __ONFT1155CoreUpgradeable_init(address _lzEndpoint) internal onlyInitializing {
+        __Ownable_init_unchained();
         __LzAppUpgradeable_init_unchained(_lzEndpoint);
     }
 
@@ -105,5 +106,5 @@ abstract contract ONFT1155CoreUpgradeable is Initializable, NonblockingLzAppUpgr
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint[48] private __gap;
+    uint[49] private __gap;
 }

--- a/contracts/contracts-upgradable/token/onft/1155/ONFT1155Upgradable.sol
+++ b/contracts/contracts-upgradable/token/onft/1155/ONFT1155Upgradable.sol
@@ -2,16 +2,16 @@
 
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol";
-import "./ONFT1155CoreUpgradeable.sol";
 import "./IONFT1155Upgradeable.sol";
-import "hardhat/console.sol";
+import "./ONFT1155CoreUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol";
 
 // NOTE: this ONFT contract has no public minting logic.
 // must implement your own minting logic in child classes
 contract ONFT1155Upgradeable is Initializable, ONFT1155CoreUpgradeable, ERC1155Upgradeable, IONFT1155Upgradeable {
     function __ONFT1155Upgradeable_init(string memory _uri, address _lzEndpoint) internal onlyInitializing {
         __ERC1155_init_unchained(_uri);
+        __Ownable_init_unchained();
         __LzAppUpgradeable_init_unchained(_lzEndpoint);
     }
 

--- a/contracts/contracts-upgradable/token/onft/721/ONFT721CoreUpgradeable.sol
+++ b/contracts/contracts-upgradable/token/onft/721/ONFT721CoreUpgradeable.sol
@@ -2,10 +2,9 @@
 
 pragma solidity ^0.8.2;
 
-import "../../../lzApp/NonblockingLzAppUpgradeable.sol";
 import "./IONFT721CoreUpgradeable.sol";
+import "../../../lzApp/NonblockingLzAppUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/utils/introspection/IERC165Upgradeable.sol";
 
 abstract contract ONFT721CoreUpgradeable is Initializable, NonblockingLzAppUpgradeable, ERC165Upgradeable, IONFT721CoreUpgradeable {
     uint16 public constant FUNCTION_TYPE_SEND = 1;
@@ -13,7 +12,7 @@ abstract contract ONFT721CoreUpgradeable is Initializable, NonblockingLzAppUpgra
     struct StoredCredit {
         uint16 srcChainId;
         address toAddress;
-        uint256 index;
+        uint256 index; // which index of the tokenIds remain
         bool creditsRemain;
     }
 
@@ -23,6 +22,7 @@ abstract contract ONFT721CoreUpgradeable is Initializable, NonblockingLzAppUpgra
     mapping(bytes32 => StoredCredit) public storedCredits;
 
     function __ONFT721CoreUpgradeable_init(uint256 _minGasToTransferAndStore, address _lzEndpoint) internal onlyInitializing {
+        __Ownable_init_unchained();
         __LzAppUpgradeable_init_unchained(_lzEndpoint);
         __ONFT721CoreUpgradeable_init_unchained(_minGasToTransferAndStore);
     }
@@ -163,5 +163,5 @@ abstract contract ONFT721CoreUpgradeable is Initializable, NonblockingLzAppUpgra
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint[44] private __gap;
+    uint[46] private __gap;
 }

--- a/contracts/contracts-upgradable/token/onft/721/ONFT721Upgradeable.sol
+++ b/contracts/contracts-upgradable/token/onft/721/ONFT721Upgradeable.sol
@@ -2,17 +2,16 @@
 
 pragma solidity ^0.8.2;
 
-import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
-import "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/utils/introspection/IERC165Upgradeable.sol";
-import "./ONFT721CoreUpgradeable.sol";
 import "./IONFT721Upgradeable.sol";
+import "./ONFT721CoreUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
 
 // NOTE: this ONFT contract has no public minting logic.
 // must implement your own minting logic in child classes
 contract ONFT721Upgradeable is Initializable, ONFT721CoreUpgradeable, ERC721Upgradeable, IONFT721Upgradeable {
     function __ONFT721Upgradeable_init(string memory _name, string memory _symbol, uint256 _minGasToTransfer, address _lzEndpoint) internal onlyInitializing {
         __ERC721_init_unchained(_name, _symbol);
+        __Ownable_init_unchained();
         __LzAppUpgradeable_init_unchained(_lzEndpoint);
         __ONFT721CoreUpgradeable_init_unchained(_minGasToTransfer);
     }


### PR DESCRIPTION
1/ update the length of the gap array
2/ call all ancestors' init_unchained()
3/ cleanup import and examples