### PR TITLE
onft extensions

### DIFF
--- a/contracts/mocks/DistributeONFT721Mock.sol
+++ b/contracts/mocks/DistributeONFT721Mock.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "../token/onft/extension/DistributeONFT721.sol";
+
+contract DistributeONFT721Mock is DistributeONFT721 {
+    constructor(
+        address _layerZeroEndpoint,
+        uint[] memory _indexArray,
+        uint[] memory _valueArray
+    ) DistributeONFT721("ExampleDistribute", "ONFT", 150000, _layerZeroEndpoint, _indexArray, _valueArray) {}
+
+    function mint() public {
+        require(countAllSetBits() >= 1, "Not enough tokens to Mint");
+        uint tokenId = _getNextMintTokenIdAndClearFlag();
+        _safeMint(msg.sender, tokenId);
+    }
+
+    function rawOwnerOf(uint256 tokenId) public view returns (address) {
+        if(_exists(tokenId)) {
+            return ownerOf(tokenId);
+        }
+        return address(0);
+    }
+}

--- a/contracts/mocks/DistributeONFT721Mock.sol
+++ b/contracts/mocks/DistributeONFT721Mock.sol
@@ -12,7 +12,7 @@ contract DistributeONFT721Mock is DistributeONFT721 {
     ) DistributeONFT721("ExampleDistribute", "ONFT", 150000, _layerZeroEndpoint, _indexArray, _valueArray) {}
 
     function mint() public {
-        require(countAllSetBits() >= 1, "Not enough tokens to Mint");
+        require(countAllSetBits() >= 1, "DistributeONFT721: Not enough tokens to Mint");
         uint tokenId = _getNextMintTokenIdAndClearFlag();
         _safeMint(msg.sender, tokenId);
     }

--- a/contracts/mocks/ONFT721AMock.sol
+++ b/contracts/mocks/ONFT721AMock.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.4;
+
+import "../token/onft/extension/ONFT721A.sol";
+
+// DISCLAIMER: This contract can only be deployed on one chain when deployed and calling
+// setTrustedRemotes with remote contracts. This is due to the sequential way 721A mints tokenIds.
+// This contract must be the first minter of each token id
+contract ONFT721AMock is ONFT721A {
+    constructor(string memory _name, string memory _symbol, uint256 _minGasToTransferAndStore, address _layerZeroEndpoint) ONFT721A(_name, _symbol, _minGasToTransferAndStore, _layerZeroEndpoint) {}
+
+    function mint(uint _amount) external payable {
+        _safeMint(msg.sender, _amount, "");
+    }
+}

--- a/contracts/mocks/ONFT721Mock.sol
+++ b/contracts/mocks/ONFT721Mock.sol
@@ -10,4 +10,11 @@ contract ONFT721Mock is ONFT721 {
     function mint(address _tokenOwner, uint _newId) external payable {
         _safeMint(_tokenOwner, _newId);
     }
+
+    function rawOwnerOf(uint256 tokenId) public view returns (address) {
+        if(_exists(tokenId)) {
+            return ownerOf(tokenId);
+        }
+        return address(0);
+    }
 }

--- a/contracts/token/onft/IONFT721Core.sol
+++ b/contracts/token/onft/IONFT721Core.sol
@@ -14,6 +14,9 @@ interface IONFT721Core is IERC165 {
      */
     event SendToChain(uint16 indexed _dstChainId, address indexed _from, bytes indexed _toAddress, uint[] _tokenIds);
     event ReceiveFromChain(uint16 indexed _srcChainId, bytes indexed _srcAddress, address indexed _toAddress, uint[] _tokenIds);
+    event SetMinGasToTransferAndStore(uint256 _minGasToTransferAndStore);
+    event SetDstChainIdToTransferGas(uint16 _dstChainId, uint256 _dstChainIdToTransferGas);
+    event SetDstChainIdToBatchLimit(uint16 _dstChainId, uint256 _dstChainIdToBatchLimit);
 
     /**
      * @dev Emitted when `_payload` was received from lz, but not enough gas to deliver all tokenIds

--- a/contracts/token/onft/ONFT721Core.sol
+++ b/contracts/token/onft/ONFT721Core.sol
@@ -22,7 +22,7 @@ abstract contract ONFT721Core is NonblockingLzApp, ERC165, IONFT721Core {
     mapping(bytes32 => StoredCredit) public storedCredits;
 
     constructor(uint256 _minGasToTransferAndStore, address _lzEndpoint) NonblockingLzApp(_lzEndpoint) {
-        require(_minGasToTransferAndStore > 0, "ONFT721: minGasToTransferAndStore must be > 0");
+        require(_minGasToTransferAndStore > 0, "minGasToTransferAndStore must be > 0");
         minGasToTransferAndStore = _minGasToTransferAndStore;
     }
 
@@ -49,8 +49,8 @@ abstract contract ONFT721Core is NonblockingLzApp, ERC165, IONFT721Core {
 
     function _send(address _from, uint16 _dstChainId, bytes memory _toAddress, uint[] memory _tokenIds, address payable _refundAddress, address _zroPaymentAddress, bytes memory _adapterParams) internal virtual {
         // allow 1 by default
-        require(_tokenIds.length > 0, "LzApp: tokenIds[] is empty");
-        require(_tokenIds.length == 1 || _tokenIds.length <= dstChainIdToBatchLimit[_dstChainId], "ONFT721: batch size exceeds dst batch limit");
+        require(_tokenIds.length > 0, "tokenIds[] is empty");
+        require(_tokenIds.length == 1 || _tokenIds.length <= dstChainIdToBatchLimit[_dstChainId], "batch size exceeds dst batch limit");
 
         for (uint i = 0; i < _tokenIds.length; i++) {
             _debitFrom(_from, _dstChainId, _toAddress, _tokenIds[i]);
@@ -91,12 +91,12 @@ abstract contract ONFT721Core is NonblockingLzApp, ERC165, IONFT721Core {
     // Public function for anyone to clear and deliver the remaining batch sent tokenIds
     function clearCredits(bytes memory _payload) external virtual {
         bytes32 hashedPayload = keccak256(_payload);
-        require(storedCredits[hashedPayload].creditsRemain, "ONFT721: no credits stored");
+        require(storedCredits[hashedPayload].creditsRemain, "no credits stored");
 
         (, uint[] memory tokenIds) = abi.decode(_payload, (bytes, uint[]));
 
         uint nextIndex = _creditTill(storedCredits[hashedPayload].srcChainId, storedCredits[hashedPayload].toAddress, storedCredits[hashedPayload].index, tokenIds);
-        require(nextIndex > storedCredits[hashedPayload].index, "ONFT721: not enough gas to process credit transfer");
+        require(nextIndex > storedCredits[hashedPayload].index, "not enough gas to process credit transfer");
 
         if (nextIndex == tokenIds.length) {
             // cleared the credits, delete the element
@@ -126,20 +126,23 @@ abstract contract ONFT721Core is NonblockingLzApp, ERC165, IONFT721Core {
     }
 
     function setMinGasToTransferAndStore(uint256 _minGasToTransferAndStore) external onlyOwner {
-        require(_minGasToTransferAndStore > 0, "ONFT721: minGasToTransferAndStore must be > 0");
+        require(_minGasToTransferAndStore > 0, "minGasToTransferAndStore must be > 0");
         minGasToTransferAndStore = _minGasToTransferAndStore;
+        emit SetMinGasToTransferAndStore(_minGasToTransferAndStore);
     }
 
     // ensures enough gas in adapter params to handle batch transfer gas amounts on the dst
     function setDstChainIdToTransferGas(uint16 _dstChainId, uint256 _dstChainIdToTransferGas) external onlyOwner {
-        require(_dstChainIdToTransferGas > 0, "ONFT721: dstChainIdToTransferGas must be > 0");
+        require(_dstChainIdToTransferGas > 0, "dstChainIdToTransferGas must be > 0");
         dstChainIdToTransferGas[_dstChainId] = _dstChainIdToTransferGas;
+        emit SetDstChainIdToTransferGas(_dstChainId, _dstChainIdToTransferGas);
     }
 
     // limit on src the amount of tokens to batch send
     function setDstChainIdToBatchLimit(uint16 _dstChainId, uint256 _dstChainIdToBatchLimit) external onlyOwner {
-        require(_dstChainIdToBatchLimit > 0, "ONFT721: dstChainIdToBatchLimit must be > 0");
+        require(_dstChainIdToBatchLimit > 0, "dstChainIdToBatchLimit must be > 0");
         dstChainIdToBatchLimit[_dstChainId] = _dstChainIdToBatchLimit;
+        emit SetDstChainIdToBatchLimit(_dstChainId, _dstChainIdToBatchLimit);
     }
 
     function _debitFrom(address _from, uint16 _dstChainId, bytes memory _toAddress, uint _tokenId) internal virtual;

--- a/contracts/token/onft/extension/DistributeONFT721.sol
+++ b/contracts/token/onft/extension/DistributeONFT721.sol
@@ -52,8 +52,8 @@ contract DistributeONFT721 is ONFT721 {
     uint16 public constant NUM_TOKENS_PER_INDEX = 250;
     uint16 public constant MAX_TOKENS_PER_INDEX = 256;
 
-    uint public distributeBaseDstGas = 40000;
-    uint public distributeGasPerIdx = 5000;
+    uint public distributeBaseDstGas = 50000;
+    uint public distributeGasPerIdx = 25000;
 
     event Distribute(uint16 indexed _srcChainId, TokenDistribute[] tokenDistribute);
     event ReceiveDistribute(uint16 indexed _srcChainId, bytes indexed _srcAddress, TokenDistribute[] tokenDistribute);
@@ -119,6 +119,7 @@ contract DistributeONFT721 is ONFT721 {
         uint tokenIdsLength = tokenIds.length;
 
         TokenDistribute[] memory tokenDistributeFixed = new TokenDistribute[](tokenDistributeSize);
+        uint index;
         for(uint i; i < tokenIdsLength;) {
             uint currentTokenId = tokenIds[i];
             if(currentTokenId == 0) {
@@ -136,8 +137,8 @@ contract DistributeONFT721 is ONFT721 {
                 amountNeeded -= 1;
                 if(currentTokenId == 0) break;
             }
-            tokenDistributeFixed[i] = TokenDistribute(i, sendValue);
-            unchecked{++i;}
+            tokenDistributeFixed[index] = TokenDistribute(i, sendValue);
+            unchecked{++i;++index;}
         }
 
         return tokenDistributeFixed;
@@ -252,12 +253,15 @@ contract DistributeONFT721 is ONFT721 {
     }
 
     function _countTokenDistributeSize(uint _amount) internal view returns (uint) {
-        uint count;
+        uint totalCount;
+        uint size;
         uint tokenIdsLength = tokenIds.length;
         for(uint i; i < tokenIdsLength;) {
             uint currentTokenId = tokenIds[i];
-            count += BitLib.countSetBits(currentTokenId);
-            if(count >= _amount) return i + 1;
+            uint count = BitLib.countSetBits(currentTokenId);
+            if(count > 0) size += 1;
+            totalCount += count;
+            if(totalCount >= _amount) return size;
             unchecked{++i;}
         }
         return 0;

--- a/contracts/token/onft/extension/DistributeONFT721.sol
+++ b/contracts/token/onft/extension/DistributeONFT721.sol
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.0;
+
+import "../ONFT721.sol";
+import "../../../util/BitLib.sol";
+
+/**
+ DistributeONFT allows for contracts to distribute unused token ids to other chains. Default is set to 10,000 token ids
+ w/ 2500 tokens on 4 chains. Uses uint[](40) to keep track of token ids on current chain. Each uint in the array uses
+ 250 bits of its allotted 256 bits to represent token ids. If the bit is set to 1 then that token id can be minted.
+ Token Ids are defined by where they are in the tokenIds array.
+ For example:
+      [0]: 1-250,
+      [1]: 251-500,
+      [2]: 501-750,
+      ... ,
+      [40]: 9751-10000
+
+Example using 8 bits to represent token distribution:
+
+             Chain A | Chain B
+tokenIds[0]: 0xff    | 0x0
+tokenIds[1]: 0x0     | 0xff
+
+Binary equivalent:
+
+              Chain A   |  Chain B
+tokenIds[0]: 1111 1111  | 0000 0000
+tokenIds[1]: 0000 0000  | 1111 1111
+
+In this scenario Chain A owns tokenIds: 1,2,3,4,5,6,7,8 and Chain B owns tokenIds: 9,10,11,12,13,14,15,16
+
+Chain A wants to send over 2 Token Ids to Chain B
+
+             Chain A | Chain B
+tokenIds[0]: 0x3f    | 0xc0
+tokenIds[1]: 0x0     | 0xff
+
+Binary equivalent:
+
+              Chain A   |  Chain B
+tokenIds[0]: 0011 1111  | 1100 0000
+tokenIds[1]: 0000 0000  | 1111 1111
+
+Now Chain A owns tokenIds: 3,4,5,6,7,8 and Chain B owns tokenIds: 1,2,9,10,11,12,13,14,15,16
+**/
+contract DistributeONFT721 is ONFT721 {
+
+    uint16 public constant FUNCTION_TYPE_DISTRIBUTE = 2;
+    uint16 public constant NUM_TOKENS_PER = 250;
+
+    event Distribute(uint16 indexed _srcChainId, TokenDistribute[] tokenDistribute);
+    event ReceiveDistribute(uint16 indexed _srcChainId, bytes indexed _srcAddress, TokenDistribute[] tokenDistribute);
+
+    struct TokenDistribute {
+        uint index;
+        uint value;
+    }
+
+    uint[] public tokenIds = new uint[](40);
+
+    /// @notice Constructor for the DistributeONFT721
+    /// @param _name the name of the token
+    /// @param _symbol the token symbol
+    /// @param _layerZeroEndpoint handles message transmission across chains
+    /// @param _indexArray to set to all ones representing token ids available to mint
+    constructor(string memory _name, string memory _symbol, uint256 _minGasToTransfer, address _layerZeroEndpoint, uint[] memory _indexArray, uint[] memory _valueArray) ONFT721(_name, _symbol, _minGasToTransfer, _layerZeroEndpoint){
+        //TODO add validation only using 250 bits of allotted 256
+        uint _indexArrayLength = _indexArray.length;
+        for(uint i; i < _indexArrayLength;) {
+            tokenIds[_indexArray[i]] = _valueArray[i];
+            unchecked{++i;}
+        }
+    }
+
+    //---------------------------Public Functions----------------------------------------
+    function estimateSendBatchFee(uint16 _dstChainId, bytes memory _toAddress, uint[] memory _tokenIds, bool _useZro, bytes memory _adapterParams) public view virtual override(IONFT721Core,ONFT721Core) returns (uint nativeFee, uint zroFee) {
+        bytes memory payload = abi.encode(FUNCTION_TYPE_SEND, _toAddress, _tokenIds);
+        return lzEndpoint.estimateFees(_dstChainId, address(this), payload, _useZro, _adapterParams);
+    }
+
+    function countAllSetBits() public view returns (uint count) {
+        uint tokenIdsLength = tokenIds.length;
+        for(uint i; i < tokenIdsLength;) {
+            if(tokenIds[i] > 0) {
+                count += BitLib.countSetBits(tokenIds[i]);
+            }
+            unchecked{++i;}
+        }
+        return count;
+    }
+
+    //---------------------------External Functions----------------------------------------
+
+    function distributeTokens(uint16 _dstChainId, TokenDistribute[] memory _tokenDistribute, address payable _refundAddress, address _zroPaymentAddress) external payable onlyOwner {
+        require(_verifyAmounts(_tokenDistribute), "Invalid input");
+        _flipBits(_tokenDistribute);
+        bytes memory payload = abi.encode(FUNCTION_TYPE_DISTRIBUTE, _tokenDistribute);
+        bytes memory _adapterParams = _getMultiAdaptParams(_tokenDistribute.length);
+        _lzSend(_dstChainId, payload, _refundAddress, _zroPaymentAddress, _adapterParams, msg.value);
+        emit Distribute(_dstChainId, _tokenDistribute);
+    }
+
+    function getDistributeTokens(uint _amount) external view returns (TokenDistribute[] memory) {
+        uint tokenDistributeSize = _countTokenDistributeSize(_amount);
+
+        require(tokenDistributeSize != 0, "Not enough tokens to distribute");
+
+        uint amountNeeded = _amount;
+
+        uint tokenIdsLength = tokenIds.length;
+
+        TokenDistribute[] memory tokenDistributeFixed = new TokenDistribute[](tokenDistributeSize);
+        for(uint i; i < tokenIdsLength;) {
+            uint currentTokenId = tokenIds[i];
+            if(currentTokenId == 0) {
+                unchecked{++i;}
+                continue;
+            }
+            if(amountNeeded == 0) break;
+            uint sendValue;
+            uint position;
+            while(amountNeeded != 0) {
+                position = BitLib.mostSignificantBitPosition(currentTokenId);
+                uint temp = 1 << position;
+                currentTokenId = currentTokenId ^ temp;
+                sendValue = sendValue | temp;
+                amountNeeded -= 1;
+                if(currentTokenId == 0) break;
+            }
+            tokenDistributeFixed[i] = TokenDistribute(i, sendValue);
+            unchecked{++i;}
+        }
+
+        return tokenDistributeFixed;
+    }
+
+    function estimateDistributeFee(uint16 _dstChainId, TokenDistribute[] memory _tokenDistribute, bool _useZro) external view returns (uint nativeFee, uint zroFee) {
+        return _estimatePayloadFee(_dstChainId, abi.encode(FUNCTION_TYPE_DISTRIBUTE, _tokenDistribute), _tokenDistribute.length, _useZro);
+    }
+
+    //---------------------------Internal Functions----------------------------------------
+
+    // override _send in ONFT721Core to pass in FUNCTION_TYPE into payload
+    function _send(address _from, uint16 _dstChainId, bytes memory _toAddress, uint[] memory _tokenIds, address payable _refundAddress, address _zroPaymentAddress, bytes memory _adapterParams) internal virtual override(ONFT721Core) {
+        // allow 1 by default
+        require(_tokenIds.length > 0, "LzApp: tokenIds[] is empty");
+        require(_tokenIds.length == 1 || _tokenIds.length <= dstChainIdToBatchLimit[_dstChainId], "ONFT721: batch size exceeds dst batch limit");
+
+        for (uint i = 0; i < _tokenIds.length; i++) {
+            _debitFrom(_from, _dstChainId, _toAddress, _tokenIds[i]);
+        }
+
+        bytes memory payload = abi.encode(FUNCTION_TYPE_SEND, _toAddress, _tokenIds);
+
+        _checkGasLimit(_dstChainId, FUNCTION_TYPE_SEND, _adapterParams, dstChainIdToTransferGas[_dstChainId] * _tokenIds.length);
+        _lzSend(_dstChainId, payload, _refundAddress, _zroPaymentAddress, _adapterParams, msg.value);
+        emit SendToChain(_dstChainId, _from, _toAddress, _tokenIds);
+    }
+
+    function _nonblockingLzReceive(
+        uint16 _srcChainId,
+        bytes memory _srcAddress,
+        uint64, /*_nonce*/
+        bytes memory _payload
+    ) internal virtual override {
+        uint8 functionType;
+        assembly {
+            functionType := mload(add(_payload, 32))
+        }
+
+        if(functionType == FUNCTION_TYPE_SEND) {
+            // decode and load the toAddress
+            (,bytes memory toAddressBytes, uint[] memory tokenIds) = abi.decode(_payload, (uint16, bytes, uint[]));
+
+            address toAddress;
+            assembly {
+                toAddress := mload(add(toAddressBytes, 20))
+            }
+
+            uint nextIndex = _creditTill(_srcChainId, toAddress, 0, tokenIds);
+            if (nextIndex < tokenIds.length) {
+                // not enough gas to complete transfers, store to be cleared in another tx
+                bytes32 hashedPayload = keccak256(_payload);
+                storedCredits[hashedPayload] = StoredCredit(_srcChainId, toAddress, nextIndex, true);
+                emit CreditStored(hashedPayload, _payload);
+            }
+
+            emit ReceiveFromChain(_srcChainId, _srcAddress, toAddress, tokenIds);
+        } else if(functionType == FUNCTION_TYPE_DISTRIBUTE) {
+            (, TokenDistribute[] memory tokenDistribute) = abi.decode(_payload, (uint16, TokenDistribute[]));
+            uint tokenDistributeLength = tokenDistribute.length;
+            for(uint i; i < tokenDistributeLength;) {
+                uint temp = tokenIds[tokenDistribute[i].index];
+                tokenIds[tokenDistribute[i].index] = temp | tokenDistribute[i].value;
+                unchecked{++i;}
+            }
+            emit ReceiveDistribute(_srcChainId, _srcAddress, tokenDistribute);
+        }
+    }
+
+    // Public function for anyone to clear and deliver the remaining batch sent tokenIds
+    function clearCredits(bytes memory _payload) external virtual override {
+        bytes32 hashedPayload = keccak256(_payload);
+        require(storedCredits[hashedPayload].creditsRemain, "ONFT721: no credits stored");
+
+        (,, uint[] memory tokenIds) = abi.decode(_payload, (uint16, bytes, uint[]));
+
+        uint nextIndex = _creditTill(storedCredits[hashedPayload].srcChainId, storedCredits[hashedPayload].toAddress, storedCredits[hashedPayload].index, tokenIds);
+        require(nextIndex > storedCredits[hashedPayload].index, "ONFT721: not enough gas to process credit transfer");
+
+        if (nextIndex == tokenIds.length) {
+            // cleared the credits, delete the element
+            delete storedCredits[hashedPayload];
+            emit CreditCleared(hashedPayload);
+        } else {
+            // store the next index to mint
+            storedCredits[hashedPayload] = StoredCredit(storedCredits[hashedPayload].srcChainId, storedCredits[hashedPayload].toAddress, nextIndex, true);
+        }
+    }
+
+    function _verifyAmounts(TokenDistribute[] memory _tokenDistribute) internal view returns (bool) {
+        uint tokenDistributeLength = _tokenDistribute.length;
+        for(uint i; i < tokenDistributeLength;) {
+            uint tempTokenIds = tokenIds[_tokenDistribute[i].index];
+            uint result = tempTokenIds & _tokenDistribute[i].value;
+            if(result != _tokenDistribute[i].value) return false;
+            unchecked{++i;}
+        }
+        return true;
+    }
+
+    function _flipBits(TokenDistribute[] memory _tokenDistribute) internal {
+        uint tokenDistributeLength = _tokenDistribute.length;
+        for(uint i; i < tokenDistributeLength;) {
+            tokenIds[_tokenDistribute[i].index] = tokenIds[_tokenDistribute[i].index] ^ _tokenDistribute[i].value;
+            unchecked{++i;}
+        }
+    }
+
+    function _estimatePayloadFee(uint16 _dstChainId, bytes memory _payload, uint _amount, bool _useZro) internal view returns (uint nativeFee, uint zroFee) {
+        require(_amount > 0, "Amount must be greater than 0");
+        uint16 version = 1;
+        uint destinationGas = 200000 + ((_amount - 1) * 50000);
+        bytes memory _adapterParams = abi.encodePacked(version, destinationGas);
+        return lzEndpoint.estimateFees(_dstChainId, address(this), _payload, _useZro, _adapterParams);
+    }
+
+    function _countTokenDistributeSize(uint _amount) internal view returns (uint) {
+        uint count;
+        uint tokenIdsLength = tokenIds.length;
+        for(uint i; i < tokenIdsLength;) {
+            uint currentTokenId = tokenIds[i];
+            count += BitLib.countSetBits(currentTokenId);
+            if(count >= _amount) return i + 1;
+            unchecked{++i;}
+        }
+        return 0;
+    }
+
+    function _getMultiAdaptParams(uint _amount) internal pure returns (bytes memory) {
+        require(_amount > 0, "Amount must be greater than 0");
+        uint16 version = 1;
+        uint destinationGas = 200000 + ((_amount - 1) * 50000);
+        return abi.encodePacked(version, destinationGas);
+    }
+
+    function _getNextMintTokenIdAndClearFlag() internal returns (uint tokenId) {
+        uint tokenIdsLength = tokenIds.length;
+        for(uint i; i < tokenIdsLength;) {
+            uint currentTokenId = tokenIds[i];
+            if(currentTokenId == 0) {
+                unchecked{++i;}
+                continue;
+            }
+            uint position = BitLib.mostSignificantBitPosition(currentTokenId);
+            uint temp = 1 << position;
+            tokenIds[i] = tokenIds[i] ^ temp;
+            tokenId = (255 - position) + (i * NUM_TOKENS_PER) + 1;
+            break;
+        }
+        return tokenId;
+    }
+}

--- a/contracts/token/onft/extension/DistributeONFT721.sol
+++ b/contracts/token/onft/extension/DistributeONFT721.sol
@@ -52,8 +52,8 @@ contract DistributeONFT721 is ONFT721 {
     uint16 public constant NUM_TOKENS_PER_INDEX = 250;
     uint16 public constant MAX_TOKENS_PER_INDEX = 256;
 
-    uint public distributeBaseDstGas = 200000;
-    uint public distributeGasPerIdx = 50000;
+    uint public distributeBaseDstGas = 40000;
+    uint public distributeGasPerIdx = 5000;
 
     event Distribute(uint16 indexed _srcChainId, TokenDistribute[] tokenDistribute);
     event ReceiveDistribute(uint16 indexed _srcChainId, bytes indexed _srcAddress, TokenDistribute[] tokenDistribute);

--- a/contracts/token/onft/extension/DistributeONFT721.sol
+++ b/contracts/token/onft/extension/DistributeONFT721.sol
@@ -74,6 +74,7 @@ contract DistributeONFT721 is ONFT721 {
     /// @param _indexArray to set to all ones representing token ids available to mint
     constructor(string memory _name, string memory _symbol, uint256 _minGasToTransfer, address _layerZeroEndpoint, uint[] memory _indexArray, uint[] memory _valueArray) ONFT721(_name, _symbol, _minGasToTransfer, _layerZeroEndpoint){
         uint _indexArrayLength = _indexArray.length;
+        require(_indexArrayLength == _valueArray.length, "_indexArray and _valueArray must be same length");
         for(uint i; i < _indexArrayLength;) {
             tokenIds[_indexArray[i]] = _valueArray[i];
             unchecked{++i;}

--- a/contracts/token/onft/extension/DistributeONFT721.sol
+++ b/contracts/token/onft/extension/DistributeONFT721.sol
@@ -110,6 +110,7 @@ contract DistributeONFT721 is ONFT721 {
     }
 
     function getDistributeTokens(uint _amount) external view returns (TokenDistribute[] memory) {
+        require(_amount > 0, "_amount must be > 0");
         uint tokenDistributeSize = _countTokenDistributeSize(_amount);
 
         require(tokenDistributeSize != 0, "Not enough tokens to distribute");

--- a/contracts/token/onft/extension/ONFT721A.sol
+++ b/contracts/token/onft/extension/ONFT721A.sol
@@ -7,7 +7,7 @@ import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import "erc721a/contracts/ERC721A.sol";
 import "erc721a/contracts/IERC721A.sol";
 import "../IONFT721.sol";
-import "../../../lzApp/NonblockingLzApp.sol";
+import "../ONFT721Core.sol";
 
 // DISCLAIMER:
 // This contract can only be deployed on one chain and must be the first minter of each token id!
@@ -16,161 +16,21 @@ import "../../../lzApp/NonblockingLzApp.sol";
 
 // NOTE: this ONFT contract has no public minting logic.
 // must implement your own minting logic in child contract
-contract ONFT721A is NonblockingLzApp, ERC721A, ERC721A__IERC721Receiver, ERC165, IONFT721Core {
-    uint16 public constant FUNCTION_TYPE_SEND = 1;
+contract ONFT721A is ONFT721Core, ERC721A, ERC721A__IERC721Receiver {
 
-    struct StoredCredit {
-        uint16 srcChainId;
-        address toAddress;
-        uint256 index; // which index of the tokenIds remain
-        bool creditsRemain;
-    }
+    constructor(string memory _name, string memory _symbol, uint256 _minGasToTransferAndStore, address _lzEndpoint) ERC721A(_name, _symbol) ONFT721Core(_minGasToTransferAndStore, _lzEndpoint) {}
 
-    uint256 public minGasToTransferAndStore; // min amount of gas required to transfer, and also store the payload
-    mapping(uint16 => uint256) public dstChainIdToBatchLimit;
-    mapping(uint16 => uint256) public dstChainIdToTransferGas; // per transfer amount of gas required to mint/transfer on the dst
-    mapping(bytes32 => StoredCredit) public storedCredits;
-
-    constructor(string memory _name, string memory _symbol, uint256 _minGasToTransferAndStore, address _lzEndpoint) ERC721A(_name, _symbol) NonblockingLzApp(_lzEndpoint) {
-        require(_minGasToTransferAndStore > 0, "minGasToTransferAndStore must be > 0");
-        minGasToTransferAndStore = _minGasToTransferAndStore;
-    }
-
-    function supportsInterface(bytes4 interfaceId) public view virtual override(ERC721A, ERC165, IERC165) returns (bool) {
+    function supportsInterface(bytes4 interfaceId) public view virtual override(ONFT721Core, ERC721A) returns (bool) {
         return interfaceId == type(IONFT721Core).interfaceId || super.supportsInterface(interfaceId);
     }
 
-    function estimateSendFee(uint16 _dstChainId, bytes memory _toAddress, uint _tokenId, bool _useZro, bytes memory _adapterParams) public view virtual override returns (uint nativeFee, uint zroFee) {
-        return estimateSendBatchFee(_dstChainId, _toAddress, _toSingletonArray(_tokenId), _useZro, _adapterParams);
-    }
-
-    function estimateSendBatchFee(uint16 _dstChainId, bytes memory _toAddress, uint[] memory _tokenIds, bool _useZro, bytes memory _adapterParams) public view virtual override returns (uint nativeFee, uint zroFee) {
-        bytes memory payload = abi.encode(_toAddress, _tokenIds);
-        return lzEndpoint.estimateFees(_dstChainId, address(this), payload, _useZro, _adapterParams);
-    }
-
-    function sendFrom(address _from, uint16 _dstChainId, bytes memory _toAddress, uint _tokenId, address payable _refundAddress, address _zroPaymentAddress, bytes memory _adapterParams) public payable virtual override {
-        _send(_from, _dstChainId, _toAddress, _toSingletonArray(_tokenId), _refundAddress, _zroPaymentAddress, _adapterParams);
-    }
-
-    function sendBatchFrom(address _from, uint16 _dstChainId, bytes memory _toAddress, uint[] memory _tokenIds, address payable _refundAddress, address _zroPaymentAddress, bytes memory _adapterParams) public payable virtual override {
-        _send(_from, _dstChainId, _toAddress, _tokenIds, _refundAddress, _zroPaymentAddress, _adapterParams);
-    }
-
-    function _send(address _from, uint16 _dstChainId, bytes memory _toAddress, uint[] memory _tokenIds, address payable _refundAddress, address _zroPaymentAddress, bytes memory _adapterParams) internal virtual {
-        // allow 1 by default
-        require(_tokenIds.length > 0, "tokenIds[] is empty");
-        require(_tokenIds.length == 1 || _tokenIds.length <= dstChainIdToBatchLimit[_dstChainId], "batch size exceeds dst batch limit");
-
-        for (uint i = 0; i < _tokenIds.length;) {
-            _debitFrom(_from, _dstChainId, _toAddress, _tokenIds[i]);
-            unchecked{++i;}
-        }
-
-        bytes memory payload = abi.encode(_toAddress, _tokenIds);
-
-        _checkGasLimit(_dstChainId, FUNCTION_TYPE_SEND, _adapterParams, dstChainIdToTransferGas[_dstChainId] * _tokenIds.length);
-        _lzSend(_dstChainId, payload, _refundAddress, _zroPaymentAddress, _adapterParams, msg.value);
-        emit SendToChain(_dstChainId, _from, _toAddress, _tokenIds);
-    }
-
-    function _nonblockingLzReceive(
-        uint16 _srcChainId,
-        bytes memory _srcAddress,
-        uint64, /*_nonce*/
-        bytes memory _payload
-    ) internal virtual override {
-        // decode and load the toAddress
-        (bytes memory toAddressBytes, uint[] memory tokenIds) = abi.decode(_payload, (bytes, uint[]));
-
-        address toAddress;
-        assembly {
-            toAddress := mload(add(toAddressBytes, 20))
-        }
-
-        uint nextIndex = _creditTill(_srcChainId, toAddress, 0, tokenIds);
-        if (nextIndex < tokenIds.length) {
-            // not enough gas to complete transfers, store to be cleared in another tx
-            bytes32 hashedPayload = keccak256(_payload);
-            storedCredits[hashedPayload] = StoredCredit(_srcChainId, toAddress, nextIndex, true);
-            emit CreditStored(hashedPayload, _payload);
-        }
-
-        emit ReceiveFromChain(_srcChainId, _srcAddress, toAddress, tokenIds);
-    }
-
-    // Public function for anyone to clear and deliver the remaining batch sent tokenIds
-    function clearCredits(bytes memory _payload) external virtual {
-        bytes32 hashedPayload = keccak256(_payload);
-        require(storedCredits[hashedPayload].creditsRemain, "no credits stored");
-
-        (, uint[] memory tokenIds) = abi.decode(_payload, (bytes, uint[]));
-
-        uint nextIndex = _creditTill(storedCredits[hashedPayload].srcChainId, storedCredits[hashedPayload].toAddress, storedCredits[hashedPayload].index, tokenIds);
-        require(nextIndex > storedCredits[hashedPayload].index, "not enough gas to process credit transfer");
-
-        if (nextIndex == tokenIds.length) {
-            // cleared the credits, delete the element
-            delete storedCredits[hashedPayload];
-            emit CreditCleared(hashedPayload);
-        } else {
-            // store the next index to mint
-            storedCredits[hashedPayload] = StoredCredit(storedCredits[hashedPayload].srcChainId, storedCredits[hashedPayload].toAddress, nextIndex, true);
-        }
-    }
-
-    // When a srcChain has the ability to transfer more chainIds in a single tx than the dst can do.
-    // Needs the ability to iterate and stop if the minGasToTransferAndStore is not met
-    function _creditTill(uint16 _srcChainId, address _toAddress, uint _startIndex, uint[] memory _tokenIds) internal returns (uint256){
-        uint i = _startIndex;
-        while (i < _tokenIds.length) {
-            // if not enough gas to process, store this index for next loop
-            if (gasleft() < minGasToTransferAndStore) break;
-
-            _creditTo(_srcChainId, _toAddress, _tokenIds[i]);
-            i++;
-        }
-
-        // indicates the next index to send of tokenIds,
-        // if i == tokenIds.length, we are finished
-        return i;
-    }
-
-    function setMinGasToTransferAndStore(uint256 _minGasToTransferAndStore) external onlyOwner {
-        require(_minGasToTransferAndStore > 0, "minGasToTransferAndStore must be > 0");
-        minGasToTransferAndStore = _minGasToTransferAndStore;
-    }
-
-    // ensures enough gas in adapter params to handle batch transfer gas amounts on the dst
-    function setDstChainIdToTransferGas(uint16 _dstChainId, uint256 _dstChainIdToTransferGas) external onlyOwner {
-        require(_dstChainIdToTransferGas > 0, "dstChainIdToTransferGas must be > 0");
-        dstChainIdToTransferGas[_dstChainId] = _dstChainIdToTransferGas;
-    }
-
-    // limit on src the amount of tokens to batch send
-    function setDstChainIdToBatchLimit(uint16 _dstChainId, uint256 _dstChainIdToBatchLimit) external onlyOwner {
-        require(_dstChainIdToBatchLimit > 0, "dstChainIdToBatchLimit must be > 0");
-        dstChainIdToBatchLimit[_dstChainId] = _dstChainIdToBatchLimit;
-    }
-
-    function _debitFrom(address _from, uint16, bytes memory, uint _tokenId) internal virtual {
+    function _debitFrom(address _from, uint16, bytes memory, uint _tokenId) override(ONFT721Core) internal virtual {
         safeTransferFrom(_from, address(this), _tokenId);
     }
 
-    function _creditTo(uint16, address _toAddress, uint _tokenId) internal virtual {
-        require(!_exists(_tokenId) || (_exists(_tokenId) && ERC721A.ownerOf(_tokenId) == address(this)));
-
-        if (!_exists(_tokenId)) {
-            _safeMint(_toAddress, _tokenId);
-        } else {
-            safeTransferFrom(address(this), _toAddress, _tokenId);
-        }
-    }
-
-    function _toSingletonArray(uint element) internal pure returns (uint[] memory) {
-        uint[] memory array = new uint[](1);
-        array[0] = element;
-        return array;
+    function _creditTo(uint16, address _toAddress, uint _tokenId) override(ONFT721Core) internal virtual {
+        require(_exists(_tokenId) && ERC721A.ownerOf(_tokenId) == address(this));
+        safeTransferFrom(address(this), _toAddress, _tokenId);
     }
 
     function onERC721Received(address, address, uint, bytes memory) public virtual override returns (bytes4) {

--- a/contracts/util/BitLib.sol
+++ b/contracts/util/BitLib.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.5.0;
+
+// mostSignificantBitPosition taken from: https://github.com/Uniswap/solidity-lib/blob/master/contracts/libraries/BitMath.sol
+// countSetBits based off: https://en.wikipedia.org/wiki/Hamming_weight
+
+library BitLib {
+
+    uint256 constant m1  = 0x5555555555555555555555555555555555555555555555555555555555555555;
+    uint256 constant m2  = 0x3333333333333333333333333333333333333333333333333333333333333333;
+    uint256 constant m4  = 0x0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F0F;
+    uint256 constant m8  = 0x00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF;
+    uint256 constant m16 = 0x0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF;
+    uint256 constant m32 = 0x00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF;
+    uint256 constant m64 = 0x0000000000000000FFFFFFFFFFFFFFFF0000000000000000FFFFFFFFFFFFFFFF;
+    uint256 constant m128= 0x00000000000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+
+    function mostSignificantBitPosition(uint256 x) internal pure returns (uint8 r) {
+        if(x == 0) return 0;
+
+        if (x >= 0x100000000000000000000000000000000) {
+            x >>= 128;
+            r += 128;
+        }
+        if (x >= 0x10000000000000000) {
+            x >>= 64;
+            r += 64;
+        }
+        if (x >= 0x100000000) {
+            x >>= 32;
+            r += 32;
+        }
+        if (x >= 0x10000) {
+            x >>= 16;
+            r += 16;
+        }
+        if (x >= 0x100) {
+            x >>= 8;
+            r += 8;
+        }
+        if (x >= 0x10) {
+            x >>= 4;
+            r += 4;
+        }
+        if (x >= 0x4) {
+            x >>= 2;
+            r += 2;
+        }
+        if (x >= 0x2) r += 1;
+    }
+
+    function countSetBits(uint x) internal pure returns (uint256) {
+        x = (x & m1 ) + ((x >>  1) & m1 );
+        x = (x & m2 ) + ((x >>  2) & m2 );
+        x = (x & m4 ) + ((x >>  4) & m4 );
+        x = (x & m8 ) + ((x >>  8) & m8 );
+        x = (x & m16) + ((x >> 16) & m16);
+        x = (x & m32) + ((x >> 32) & m32);
+        x = (x & m64) + ((x >> 64) & m64);
+        x = (x & m128) + ((x >> 128) & m128);
+        return x;
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -98,6 +98,10 @@ module.exports = {
     },
   },
 
+  mocha: {
+    timeout: 100000000
+  },
+
   networks: {
     ethereum: {
       url: "https://mainnet.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161", // public infura endpoint

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@openzeppelin/contracts": "^4.4.1",
     "@openzeppelin/contracts-upgradeable": "^4.6.0",
     "@openzeppelin/hardhat-upgrades": "^1.18.3",
+    "erc721a": "^4.2.3",
     "@uniswap/v2-core": "^1.0.1",
     "@uniswap/v2-periphery": "^1.1.0-beta.0",
     "dotenv": "^10.0.0",

--- a/test/contracts/onft/DistributeONFT721.test.js
+++ b/test/contracts/onft/DistributeONFT721.test.js
@@ -1,0 +1,617 @@
+const { expect } = require("chai")
+const { ethers } = require("hardhat")
+const Web3 = require("web3")
+const web3 = new Web3()
+
+describe("DistributeONFT721: ", function () {
+    const chainId_A = 1
+    const chainId_B = 2
+    const chainId_C = 3
+    const chainId_D = 4
+    const batchSizeLimit = 300
+
+    let owner, LZEndpointMock, ONFT, warlock
+    let distributeONFT721_A, distributeONFT721_B, distributeONFT721_C, distributeONFT721_D
+    let lzEndpointMock_A, lzEndpointMock_B, lzEndpointMock_C, lzEndpointMock_D
+    let initialValue = "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC0";
+    const defaultAdapterParams = ethers.utils.solidityPack(["uint16", "uint256"], [1, 250000])
+
+    before(async function () {
+        owner = (await ethers.getSigners())[0]
+        warlock = (await ethers.getSigners())[1]
+        LZEndpointMock = await ethers.getContractFactory("LZEndpointMock")
+        ONFT = await ethers.getContractFactory("DistributeONFT721Mock")
+    })
+
+    beforeEach(async function () {
+        lzEndpointMock_A = await LZEndpointMock.deploy(chainId_A)
+        lzEndpointMock_B = await LZEndpointMock.deploy(chainId_B)
+        lzEndpointMock_C = await LZEndpointMock.deploy(chainId_C)
+        lzEndpointMock_D = await LZEndpointMock.deploy(chainId_D)
+
+        let initialValueArray = [initialValue,initialValue,initialValue,initialValue,initialValue,initialValue,initialValue,initialValue,initialValue,initialValue]
+
+        // create two UniversalONFT instances
+        distributeONFT721_A = await ONFT.deploy(lzEndpointMock_A.address, [0,1,2,3,4,5,6,7,8,9], initialValueArray)
+        distributeONFT721_B = await ONFT.deploy(lzEndpointMock_B.address, [10,11,12,13,14,15,16,17,18,19], initialValueArray)
+        distributeONFT721_C = await ONFT.deploy(lzEndpointMock_C.address, [20,21,22,23,24,25,26,27,28,29], initialValueArray)
+        distributeONFT721_D = await ONFT.deploy(lzEndpointMock_D.address, [30,31,32,33,34,35,36,37,38,39], initialValueArray)
+
+        await lzEndpointMock_A.setDestLzEndpoint(distributeONFT721_B.address, lzEndpointMock_B.address)
+        await lzEndpointMock_A.setDestLzEndpoint(distributeONFT721_C.address, lzEndpointMock_C.address)
+        await lzEndpointMock_A.setDestLzEndpoint(distributeONFT721_D.address, lzEndpointMock_D.address)
+
+        await lzEndpointMock_B.setDestLzEndpoint(distributeONFT721_A.address, lzEndpointMock_A.address)
+        await lzEndpointMock_B.setDestLzEndpoint(distributeONFT721_C.address, lzEndpointMock_C.address)
+        await lzEndpointMock_B.setDestLzEndpoint(distributeONFT721_D.address, lzEndpointMock_D.address)
+
+        await lzEndpointMock_C.setDestLzEndpoint(distributeONFT721_A.address, lzEndpointMock_A.address)
+        await lzEndpointMock_C.setDestLzEndpoint(distributeONFT721_B.address, lzEndpointMock_B.address)
+        await lzEndpointMock_C.setDestLzEndpoint(distributeONFT721_D.address, lzEndpointMock_D.address)
+
+        await lzEndpointMock_D.setDestLzEndpoint(distributeONFT721_A.address, lzEndpointMock_A.address)
+        await lzEndpointMock_D.setDestLzEndpoint(distributeONFT721_B.address, lzEndpointMock_B.address)
+        await lzEndpointMock_D.setDestLzEndpoint(distributeONFT721_C.address, lzEndpointMock_C.address)
+
+
+        await distributeONFT721_A.setTrustedRemoteAddress(chainId_B, distributeONFT721_B.address)
+        await distributeONFT721_A.setTrustedRemoteAddress(chainId_C, distributeONFT721_C.address)
+        await distributeONFT721_A.setTrustedRemoteAddress(chainId_D, distributeONFT721_D.address)
+
+        await distributeONFT721_B.setTrustedRemoteAddress(chainId_A, distributeONFT721_A.address)
+        await distributeONFT721_B.setTrustedRemoteAddress(chainId_C, distributeONFT721_C.address)
+        await distributeONFT721_B.setTrustedRemoteAddress(chainId_D, distributeONFT721_D.address)
+
+        await distributeONFT721_C.setTrustedRemoteAddress(chainId_A, distributeONFT721_A.address)
+        await distributeONFT721_C.setTrustedRemoteAddress(chainId_B, distributeONFT721_B.address)
+        await distributeONFT721_C.setTrustedRemoteAddress(chainId_D, distributeONFT721_D.address)
+
+        await distributeONFT721_D.setTrustedRemoteAddress(chainId_A, distributeONFT721_A.address)
+        await distributeONFT721_D.setTrustedRemoteAddress(chainId_B, distributeONFT721_B.address)
+        await distributeONFT721_D.setTrustedRemoteAddress(chainId_C, distributeONFT721_C.address)
+
+        // set min dst gas for swap
+        await distributeONFT721_A.setMinDstGas(chainId_B, 1, 150000)
+        await distributeONFT721_A.setMinDstGas(chainId_C, 1, 150000)
+        await distributeONFT721_A.setMinDstGas(chainId_D, 1, 150000)
+
+        await distributeONFT721_B.setMinDstGas(chainId_A, 1, 150000)
+        await distributeONFT721_B.setMinDstGas(chainId_C, 1, 150000)
+        await distributeONFT721_B.setMinDstGas(chainId_D, 1, 150000)
+
+        await distributeONFT721_C.setMinDstGas(chainId_A, 1, 150000)
+        await distributeONFT721_C.setMinDstGas(chainId_B, 1, 150000)
+        await distributeONFT721_C.setMinDstGas(chainId_D, 1, 150000)
+
+        await distributeONFT721_D.setMinDstGas(chainId_A, 1, 150000)
+        await distributeONFT721_D.setMinDstGas(chainId_B, 1, 150000)
+        await distributeONFT721_D.setMinDstGas(chainId_C, 1, 150000)
+
+        // set min dst gas for distribute
+        await distributeONFT721_A.setMinDstGas(chainId_B, 2, 150000)
+        await distributeONFT721_A.setMinDstGas(chainId_C, 2, 150000)
+        await distributeONFT721_A.setMinDstGas(chainId_D, 2, 150000)
+
+        await distributeONFT721_B.setMinDstGas(chainId_A, 2, 150000)
+        await distributeONFT721_B.setMinDstGas(chainId_C, 2, 150000)
+        await distributeONFT721_B.setMinDstGas(chainId_D, 2, 150000)
+
+        await distributeONFT721_C.setMinDstGas(chainId_A, 2, 150000)
+        await distributeONFT721_C.setMinDstGas(chainId_B, 2, 150000)
+        await distributeONFT721_C.setMinDstGas(chainId_D, 2, 150000)
+
+        await distributeONFT721_D.setMinDstGas(chainId_A, 2, 150000)
+        await distributeONFT721_D.setMinDstGas(chainId_B, 2, 150000)
+        await distributeONFT721_D.setMinDstGas(chainId_C, 2, 150000)
+    })
+
+    it("contructor() - check initialization", async function () {
+        for (let i = 0; i < 10; i++) {
+            expect(await distributeONFT721_A.tokenIds(i)).to.equal(initialValue)
+            expect(await distributeONFT721_B.tokenIds(i)).to.equal("0x0")
+            expect(await distributeONFT721_C.tokenIds(i)).to.equal("0x0")
+            expect(await distributeONFT721_D.tokenIds(i)).to.equal("0x0")
+        }
+
+        for (let i = 10; i < 20; i++) {
+            expect(await distributeONFT721_A.tokenIds(i)).to.equal("0x0")
+            expect(await distributeONFT721_B.tokenIds(i)).to.equal(initialValue)
+            expect(await distributeONFT721_C.tokenIds(i)).to.equal("0x0")
+            expect(await distributeONFT721_D.tokenIds(i)).to.equal("0x0")
+        }
+
+        for (let i = 20; i < 30; i++) {
+            expect(await distributeONFT721_A.tokenIds(i)).to.equal("0x0")
+            expect(await distributeONFT721_B.tokenIds(i)).to.equal("0x0")
+            expect(await distributeONFT721_C.tokenIds(i)).to.equal(initialValue)
+            expect(await distributeONFT721_D.tokenIds(i)).to.equal("0x0")
+        }
+
+        for (let i = 30; i < 40; i++) {
+            expect(await distributeONFT721_A.tokenIds(i)).to.equal("0x0")
+            expect(await distributeONFT721_B.tokenIds(i)).to.equal("0x0")
+            expect(await distributeONFT721_C.tokenIds(i)).to.equal("0x0")
+            expect(await distributeONFT721_D.tokenIds(i)).to.equal(initialValue)
+        }
+
+        let totalTokenCount = parseInt(await distributeONFT721_A.callStatic.countAllSetBits())
+        totalTokenCount +=  parseInt(await distributeONFT721_B.callStatic.countAllSetBits())
+        totalTokenCount +=  parseInt(await distributeONFT721_C.callStatic.countAllSetBits())
+        totalTokenCount +=  parseInt(await distributeONFT721_D.callStatic.countAllSetBits())
+
+        expect(totalTokenCount).to.equal(10000)
+    })
+
+    it.skip("mint() - all tokens", async function () {
+        // console.log("distributeONFT721_A");
+        for (let i = 1; i <= 2500; i++) {
+            await distributeONFT721_A.mint()
+            expect(await distributeONFT721_A.ownerOf(i)).to.be.equal(owner.address)
+        }
+
+        // console.log("distributeONFT721_B");
+        for (let i = 2501; i <= 5000; i++) {
+            await distributeONFT721_B.mint()
+            expect(await distributeONFT721_B.ownerOf(i)).to.be.equal(owner.address)
+        }
+
+        // console.log("distributeONFT721_C");
+        for (let i = 5001; i <= 7500; i++) {
+            await distributeONFT721_C.mint()
+            expect(await distributeONFT721_C.ownerOf(i)).to.be.equal(owner.address)
+        }
+
+        // console.log("distributeONFT721_D");
+        for (let i = 7501; i <= 10000; i++) {
+            await distributeONFT721_D.mint()
+            expect(await distributeONFT721_D.ownerOf(i)).to.be.equal(owner.address)
+        }
+    })
+
+    it.skip("distributeTokens() - Random", async function () {
+        let chains = [1,2,3,4]
+        let currentValues = [2500,2500,2500,2500]
+        let currentChains = [distributeONFT721_A,distributeONFT721_B,distributeONFT721_C,distributeONFT721_D]
+        let breakFor = false;
+        for (let j = 0; j < 8 && !breakFor; j++) {
+            let currentDistributer = j % 4;
+            for (let i = 0; i < 8 && !breakFor; i++) {
+                if(i % 4 === currentDistributer) continue;
+                let randomTokens;
+                while(true) {
+                    randomTokens = Math.floor(Math.random() * (250 - 1 + 1)) + 1;
+                    if(currentValues[currentDistributer] >= randomTokens) break;
+                }
+                // console.log("-----------------------------------BEFORE-----------------------------------------------");
+                // console.log("A: " + parseInt(await distributeONFT721_A.callStatic.countAllSetBits()))
+                // console.log("B: " + parseInt(await distributeONFT721_B.callStatic.countAllSetBits()))
+                // console.log("C: " + parseInt(await distributeONFT721_C.callStatic.countAllSetBits()))
+                // console.log("D: " + parseInt(await distributeONFT721_D.callStatic.countAllSetBits()))
+                // console.log("-----------------------------------SENDING-----------------------------------------------");
+                // console.log(chainStr[currentDistributer] + " -> " + randomTokens + " -> " + chainStr[i % 4])
+                // console.log({currentDistributer, randomTokens})
+                let tokenDistribute = await currentChains[currentDistributer].getDistributeTokens(randomTokens)
+                // console.log(JSON.stringify(tokenDistribute))
+                await currentChains[currentDistributer].distributeTokens(
+                    chains[i % 4],
+                    tokenDistribute,
+                    owner.address,
+                    owner.address,
+                    { value: ethers.utils.parseEther("5")  }
+                )
+
+                currentValues[currentDistributer] -= randomTokens
+                currentValues[i % 4] += randomTokens
+                // console.log("-----------------------------------AFTER----------------------------`-------------------");
+                // console.log("A: " + parseInt(await distributeONFT721_A.callStatic.countAllSetBits()))
+                // console.log("B: " + parseInt(await distributeONFT721_B.callStatic.countAllSetBits()))
+                // console.log("C: " + parseInt(await distributeONFT721_C.callStatic.countAllSetBits()))
+                // console.log("D: " + parseInt(await distributeONFT721_D.callStatic.countAllSetBits()))
+                // console.log("A: " + parseInt(await distributeONFT721_A.callStatic.countAllSetBits()) + " " + currentValues[0])
+                // console.log("B: " + parseInt(await distributeONFT721_B.callStatic.countAllSetBits()) + " " + currentValues[1])
+                // console.log("C: " + parseInt(await distributeONFT721_C.callStatic.countAllSetBits()) + " " + currentValues[2])
+                // console.log("D: " + parseInt(await distributeONFT721_D.callStatic.countAllSetBits()) + " " + currentValues[3])
+            }
+        }
+        // console.log("after")
+        let currentDistributerCount_A = parseInt(await distributeONFT721_A.callStatic.countAllSetBits())
+        expect(currentDistributerCount_A).to.equal(currentValues[0])
+
+        let currentDistributerCount_B = parseInt(await distributeONFT721_B.callStatic.countAllSetBits())
+        expect(currentDistributerCount_B).to.equal(currentValues[1])
+
+        let currentDistributerCount_C = parseInt(await distributeONFT721_C.callStatic.countAllSetBits())
+        expect(currentDistributerCount_C).to.equal(currentValues[2])
+
+        let currentDistributerCount_D = parseInt(await distributeONFT721_D.callStatic.countAllSetBits())
+        expect(currentDistributerCount_D).to.equal(currentValues[3])
+
+        let totalTokenCount = parseInt(await distributeONFT721_A.callStatic.countAllSetBits())
+        totalTokenCount +=  parseInt(await distributeONFT721_B.callStatic.countAllSetBits())
+        totalTokenCount +=  parseInt(await distributeONFT721_C.callStatic.countAllSetBits())
+        totalTokenCount +=  parseInt(await distributeONFT721_D.callStatic.countAllSetBits())
+
+        expect(totalTokenCount).to.equal(10000)
+
+        // console.log("------------------------------------FINAL-------------------------------------------");
+        // console.log("A: " + parseInt(await distributeONFT721_A.callStatic.countAllSetBits()) + " " + currentValues[0])
+        // console.log("B: " + parseInt(await distributeONFT721_B.callStatic.countAllSetBits()) + " " + currentValues[1])
+        // console.log("C: " + parseInt(await distributeONFT721_C.callStatic.countAllSetBits()) + " " + currentValues[2])
+        // console.log("D: " + parseInt(await distributeONFT721_D.callStatic.countAllSetBits()) + " " + currentValues[3])
+    })
+
+    it("sendFrom() - your own tokens", async function () {
+        const tokenId = 1
+        await distributeONFT721_A.mint()
+
+        // verify the owner of the token is on the source chain
+        expect(await distributeONFT721_A.ownerOf(tokenId)).to.be.equal(owner.address)
+
+        // token doesn't exist on other chain
+        await expect(distributeONFT721_B.ownerOf(tokenId)).to.be.revertedWith("ERC721: invalid token ID")
+
+        // can transfer token on srcChain as regular erC721
+        await distributeONFT721_A.transferFrom(owner.address, warlock.address, tokenId)
+        expect(await distributeONFT721_A.ownerOf(tokenId)).to.be.equal(warlock.address)
+
+        // approve the proxy to swap your token
+        await distributeONFT721_A.connect(warlock).approve(distributeONFT721_A.address, tokenId)
+        // estimate nativeFees
+        let nativeFee = (await distributeONFT721_A.estimateSendFee(chainId_B, warlock.address, tokenId, false, defaultAdapterParams)).nativeFee
+        let ownerBalance = await ethers.provider.getBalance(owner.address)
+        let warlockBalance = await ethers.provider.getBalance(warlock.address)
+
+        // swaps token to other chain
+        await distributeONFT721_A.connect(warlock)["sendFrom(address,uint16,bytes,uint256,address,address,bytes)"](
+            warlock.address,
+            chainId_B,
+            warlock.address,
+            tokenId,
+            warlock.address,
+            ethers.constants.AddressZero,
+            defaultAdapterParams,
+            { value: nativeFee }
+        )
+
+        // token is burnt
+        expect(await distributeONFT721_A.ownerOf(tokenId)).to.be.equal(distributeONFT721_A.address)
+
+        // token received on the dst chain
+        expect(await distributeONFT721_B.ownerOf(tokenId)).to.be.equal(warlock.address)
+
+        // estimate nativeFees
+        nativeFee = (await distributeONFT721_B.estimateSendFee(chainId_A, warlock.address, tokenId, false, defaultAdapterParams)).nativeFee
+
+        // can send to other onft contract eg. not the original nft contract chain
+        await distributeONFT721_B.connect(warlock)["sendFrom(address,uint16,bytes,uint256,address,address,bytes)"](
+            warlock.address,
+            chainId_A,
+            warlock.address,
+            tokenId,
+            warlock.address,
+            ethers.constants.AddressZero,
+            defaultAdapterParams,
+            { value: nativeFee }
+        )
+
+        // token is burned on the sending chain
+        expect(await distributeONFT721_B.ownerOf(tokenId)).to.be.equal(distributeONFT721_B.address)
+    })
+
+    it("sendFrom() - reverts if not owner on non proxy chain", async function () {
+        const tokenId = 1
+        await distributeONFT721_A.mint()
+
+        // approve the proxy to swap your token
+        await distributeONFT721_A.approve(distributeONFT721_A.address, tokenId)
+
+        // estimate nativeFees
+        let nativeFee = (await distributeONFT721_A.estimateSendFee(chainId_B, owner.address, tokenId, false, defaultAdapterParams)).nativeFee
+
+        // swaps token to other chain
+        await distributeONFT721_A["sendFrom(address,uint16,bytes,uint256,address,address,bytes)"](owner.address, chainId_B, owner.address, tokenId, owner.address, ethers.constants.AddressZero, defaultAdapterParams, {
+            value: nativeFee,
+        })
+
+        // token received on the dst chain
+        expect(await distributeONFT721_B.ownerOf(tokenId)).to.be.equal(owner.address)
+
+        // reverts because other address does not own it
+        await expect(
+            distributeONFT721_B.connect(warlock)["sendFrom(address,uint16,bytes,uint256,address,address,bytes)"](
+                warlock.address,
+                chainId_A,
+                warlock.address,
+                tokenId,
+                warlock.address,
+                ethers.constants.AddressZero,
+                defaultAdapterParams
+            )
+        ).to.be.revertedWith("ONFT721: send caller is not owner nor approved")
+    })
+
+    it("sendFrom() - on behalf of other user", async function () {
+        const tokenId = 1
+        await distributeONFT721_A.mint()
+
+        // approve the proxy to swap your token
+        await distributeONFT721_A.approve(distributeONFT721_A.address, tokenId)
+
+        // estimate nativeFees
+        let nativeFee = (await distributeONFT721_A.estimateSendFee(chainId_B, owner.address, tokenId, false, defaultAdapterParams)).nativeFee
+
+        // swaps token to other chain
+        await distributeONFT721_A["sendFrom(address,uint16,bytes,uint256,address,address,bytes)"](owner.address, chainId_B, owner.address, tokenId, owner.address, ethers.constants.AddressZero, defaultAdapterParams, {
+            value: nativeFee,
+        })
+
+        // token received on the dst chain
+        expect(await distributeONFT721_B.ownerOf(tokenId)).to.be.equal(owner.address)
+
+        // approve the other user to send the token
+        await distributeONFT721_B.approve(warlock.address, tokenId)
+
+        // estimate nativeFees
+        nativeFee = (await distributeONFT721_B.estimateSendFee(chainId_A, warlock.address, tokenId, false, defaultAdapterParams)).nativeFee
+
+        // sends across
+        await distributeONFT721_B.connect(warlock)["sendFrom(address,uint16,bytes,uint256,address,address,bytes)"](
+            owner.address,
+            chainId_A,
+            warlock.address,
+            tokenId,
+            warlock.address,
+            ethers.constants.AddressZero,
+            defaultAdapterParams,
+            { value: nativeFee }
+        )
+
+        // token received on the dst chain
+        expect(await distributeONFT721_A.ownerOf(tokenId)).to.be.equal(warlock.address)
+    })
+
+    it("sendFrom() - reverts if contract is approved, but not the sending user", async function () {
+        const tokenId = 1
+        await distributeONFT721_A.mint()
+
+        // approve the proxy to swap your token
+        await distributeONFT721_A.approve(distributeONFT721_A.address, tokenId)
+
+        // estimate nativeFees
+        let nativeFee = (await distributeONFT721_A.estimateSendFee(chainId_B, owner.address, tokenId, false, defaultAdapterParams)).nativeFee
+
+        // swaps token to other chain
+        await distributeONFT721_A["sendFrom(address,uint16,bytes,uint256,address,address,bytes)"](owner.address, chainId_B, owner.address, tokenId, owner.address, ethers.constants.AddressZero, defaultAdapterParams, {
+            value: nativeFee,
+        })
+
+        // token received on the dst chain
+        expect(await distributeONFT721_B.ownerOf(tokenId)).to.be.equal(owner.address)
+
+        // approve the contract to swap your token
+        await distributeONFT721_B.approve(distributeONFT721_B.address, tokenId)
+
+        // reverts because contract is approved, not the user
+        await expect(
+            distributeONFT721_B.connect(warlock)["sendFrom(address,uint16,bytes,uint256,address,address,bytes)"](
+                owner.address,
+                chainId_A,
+                warlock.address,
+                tokenId,
+                warlock.address,
+                ethers.constants.AddressZero,
+                defaultAdapterParams
+            )
+        ).to.be.revertedWith("ONFT721: send caller is not owner nor approved")
+    })
+
+    it("sendFrom() - reverts if not approved on non proxy chain", async function () {
+        const tokenId = 1
+        await distributeONFT721_A.mint()
+
+        // approve the proxy to swap your token
+        await distributeONFT721_A.approve(distributeONFT721_A.address, tokenId)
+
+        // estimate nativeFees
+        let nativeFee = (await distributeONFT721_A.estimateSendFee(chainId_B, owner.address, tokenId, false, defaultAdapterParams)).nativeFee
+
+        // swaps token to other chain
+        await distributeONFT721_A["sendFrom(address,uint16,bytes,uint256,address,address,bytes)"](owner.address, chainId_B, owner.address, tokenId, owner.address, ethers.constants.AddressZero, defaultAdapterParams, {
+            value: nativeFee,
+        })
+
+        // token received on the dst chain
+        expect(await distributeONFT721_B.ownerOf(tokenId)).to.be.equal(owner.address)
+
+        // reverts because user is not approved
+        await expect(
+            distributeONFT721_B.connect(warlock)["sendFrom(address,uint16,bytes,uint256,address,address,bytes)"](
+                owner.address,
+                chainId_A,
+                warlock.address,
+                tokenId,
+                warlock.address,
+                ethers.constants.AddressZero,
+                defaultAdapterParams
+            )
+        ).to.be.revertedWith("ONFT721: send caller is not owner nor approved")
+    })
+
+    it("sendFrom() - reverts if sender does not own token", async function () {
+        const tokenIdA = 1
+        // mint to both owners
+        await distributeONFT721_A.mint()
+
+        // approve owner.address to transfer, but not the other
+        await distributeONFT721_A.setApprovalForAll(distributeONFT721_A.address, true)
+
+        await expect(
+            distributeONFT721_A.connect(warlock)["sendFrom(address,uint16,bytes,uint256,address,address,bytes)"](
+                warlock.address,
+                chainId_B,
+                warlock.address,
+                tokenIdA,
+                warlock.address,
+                ethers.constants.AddressZero,
+                defaultAdapterParams
+            )
+        ).to.be.revertedWith("ONFT721: send caller is not owner nor approved")
+        await expect(
+            distributeONFT721_A.connect(warlock)["sendFrom(address,uint16,bytes,uint256,address,address,bytes)"](
+                warlock.address,
+                chainId_B,
+                owner.address,
+                tokenIdA,
+                owner.address,
+                ethers.constants.AddressZero,
+                defaultAdapterParams
+            )
+        ).to.be.revertedWith("ONFT721: send caller is not owner nor approved")
+    })
+
+    it("sendBatchFrom()", async function () {
+        await distributeONFT721_A.setMinGasToTransferAndStore(400000)
+        await distributeONFT721_B.setMinGasToTransferAndStore(400000)
+        await distributeONFT721_A.setDstChainIdToBatchLimit(chainId_B, batchSizeLimit)
+        await distributeONFT721_B.setDstChainIdToBatchLimit(chainId_A, batchSizeLimit)
+
+        const tokenIds = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+        // mint to owner
+        for (let tokenId of tokenIds) {
+            await distributeONFT721_A.connect(warlock).mint()
+        }
+
+        // approve owner.address to transfer
+        await distributeONFT721_A.connect(warlock).setApprovalForAll(distributeONFT721_A.address, true)
+
+        // expected event params
+        const payload = ethers.utils.defaultAbiCoder.encode(["uint16", "bytes", "uint[]"], [1, warlock.address, tokenIds])
+        const hashedPayload = web3.utils.keccak256(payload)
+
+        let adapterParams = ethers.utils.solidityPack(["uint16", "uint256"], [1, 200000])
+
+        // estimate nativeFees
+        let nativeFee = (await distributeONFT721_A.estimateSendBatchFee(chainId_B, warlock.address, tokenIds, false, defaultAdapterParams)).nativeFee
+
+        // initiate batch transfer
+        await expect(distributeONFT721_A.connect(warlock).sendBatchFrom(
+            warlock.address,
+            chainId_B,
+            warlock.address,
+            tokenIds,
+            warlock.address,
+            ethers.constants.AddressZero,
+            adapterParams, // TODO might need to change this
+            { value: nativeFee }
+        )).to.emit(distributeONFT721_B, "CreditStored").withArgs(hashedPayload, payload)
+
+        // only partial amount of tokens has been sent, the rest have been stored as a credit
+        let creditedIdsA = []
+        for (let tokenId of tokenIds) {
+            let owner = await distributeONFT721_B.rawOwnerOf(tokenId)
+            if (owner == ethers.constants.AddressZero) {
+                creditedIdsA.push(tokenId)
+            } else {
+                expect(owner).to.be.equal(warlock.address)
+            }
+        }
+
+        // clear the rest of the credits
+        await expect(distributeONFT721_B.clearCredits(payload)).to.emit(distributeONFT721_B, "CreditCleared").withArgs(hashedPayload)
+
+        let creditedIdsB = []
+        for (let tokenId of creditedIdsA) {
+            let owner = await distributeONFT721_B.rawOwnerOf(tokenId)
+            if (owner == ethers.constants.AddressZero) {
+                creditedIdsB.push(tokenId)
+            } else {
+                expect(owner).to.be.equal(warlock.address)
+            }
+        }
+
+        // all ids should have cleared
+        expect(creditedIdsB.length).to.be.equal(0)
+
+        // should revert because payload is no longer valid
+        await expect(distributeONFT721_B.clearCredits(payload)).to.be.revertedWith("ONFT721: no credits stored")
+    })
+
+    it("sendBatchFrom() - large batch", async function () {
+        await distributeONFT721_A.setMinGasToTransferAndStore(400000)
+        await distributeONFT721_B.setMinGasToTransferAndStore(400000)
+        await distributeONFT721_A.setDstChainIdToBatchLimit(chainId_B, batchSizeLimit)
+        await distributeONFT721_B.setDstChainIdToBatchLimit(chainId_A, batchSizeLimit)
+
+        const tokenIds = []
+
+        for (let i = 1; i <= 300; i++) {
+            tokenIds.push(i)
+        }
+
+        // mint to owner
+        for (let tokenId of tokenIds) {
+            await distributeONFT721_A.connect(warlock).mint()
+        }
+
+        // approve owner.address to transfer
+        await distributeONFT721_A.connect(warlock).setApprovalForAll(distributeONFT721_A.address, true)
+
+        // expected event params
+        const payload = ethers.utils.defaultAbiCoder.encode(["uint16", "bytes", "uint[]"], [1, warlock.address, tokenIds])
+        const hashedPayload = web3.utils.keccak256(payload)
+
+        let adapterParams = ethers.utils.solidityPack(["uint16", "uint256"], [1, 400000])
+
+        // estimate nativeFees
+        let nativeFee = (await distributeONFT721_A.estimateSendBatchFee(chainId_B, warlock.address, tokenIds, false, adapterParams)).nativeFee
+
+        // initiate batch transfer
+        await expect(distributeONFT721_A.connect(warlock).sendBatchFrom(
+            warlock.address,
+            chainId_B,
+            warlock.address,
+            tokenIds,
+            warlock.address,
+            ethers.constants.AddressZero,
+            adapterParams, // TODO might need to change this
+            { value: nativeFee }
+        )).to.emit(distributeONFT721_B, "CreditStored").withArgs(hashedPayload, payload)
+
+        // only partial amount of tokens has been sent, the rest have been stored as a credit
+        let creditedIdsA = []
+        for (let tokenId of tokenIds) {
+            let owner = await distributeONFT721_B.rawOwnerOf(tokenId)
+            if (owner == ethers.constants.AddressZero) {
+                creditedIdsA.push(tokenId)
+            } else {
+                expect(owner).to.be.equal(warlock.address)
+            }
+        }
+
+        // console.log("Number of tokens credited: ", creditedIdsA.length)
+
+        // clear the rest of the credits
+        let tx = await(await distributeONFT721_B.clearCredits(payload)).wait()
+
+        // console.log("Total gasUsed: ", tx.gasUsed.toString())
+
+        let creditedIdsB = []
+        for (let tokenId of creditedIdsA) {
+            let owner = await distributeONFT721_B.rawOwnerOf(tokenId)
+            if (owner == ethers.constants.AddressZero) {
+                creditedIdsB.push(tokenId)
+            } else {
+                expect(owner).to.be.equal(warlock.address)
+            }
+        }
+
+        // console.log("Number of tokens credited: ", creditedIdsB.length)
+
+        // all ids should have cleared
+        expect(creditedIdsB.length).to.be.equal(0)
+
+        // should revert because payload is no longer valid
+        await expect(distributeONFT721_B.clearCredits(payload)).to.be.revertedWith("ONFT721: no credits stored")
+    })
+})

--- a/test/contracts/onft/DistributeONFT721.test.js
+++ b/test/contracts/onft/DistributeONFT721.test.js
@@ -534,7 +534,7 @@ describe("DistributeONFT721: ", function () {
         expect(creditedIdsB.length).to.be.equal(0)
 
         // should revert because payload is no longer valid
-        await expect(distributeONFT721_B.clearCredits(payload)).to.be.revertedWith("ONFT721: no credits stored")
+        await expect(distributeONFT721_B.clearCredits(payload)).to.be.revertedWith("no credits stored")
     })
 
     it("sendBatchFrom() - large batch", async function () {
@@ -612,6 +612,6 @@ describe("DistributeONFT721: ", function () {
         expect(creditedIdsB.length).to.be.equal(0)
 
         // should revert because payload is no longer valid
-        await expect(distributeONFT721_B.clearCredits(payload)).to.be.revertedWith("ONFT721: no credits stored")
+        await expect(distributeONFT721_B.clearCredits(payload)).to.be.revertedWith("no credits stored")
     })
 })

--- a/test/contracts/onft/ONFT721.test.js
+++ b/test/contracts/onft/ONFT721.test.js
@@ -339,7 +339,7 @@ describe("ONFT721: ", function () {
         expect(creditedIdsB.length).to.be.equal(0)
 
         // should revert because payload is no longer valid
-        await expect(ONFT_B.clearCredits(payload)).to.be.revertedWith("ONFT721: no credits stored")
+        await expect(ONFT_B.clearCredits(payload)).to.be.revertedWith("no credits stored")
     })
 
     it("sendBatchFrom() - large batch", async function () {
@@ -415,6 +415,6 @@ describe("ONFT721: ", function () {
         expect(creditedIdsB.length).to.be.equal(0)
 
         // should revert because payload is no longer valid
-        await expect(ONFT_B.clearCredits(payload)).to.be.revertedWith("ONFT721: no credits stored")
+        await expect(ONFT_B.clearCredits(payload)).to.be.revertedWith("no credits stored")
     })
 })

--- a/test/contracts/onft/ONFT721A.test.js
+++ b/test/contracts/onft/ONFT721A.test.js
@@ -3,71 +3,66 @@ const { ethers } = require("hardhat")
 const Web3 = require("web3")
 const web3 = new Web3()
 
-describe("ONFT721: ", function () {
+describe("ONFT721A: ", function () {
     const chainId_A = 1
     const chainId_B = 2
     const name = "OmnichainNonFungibleToken"
-    const symbol = "ONFT"
-    const minGasToStore = 150000
+    const symbol = "ONFT721A"
+    const defaultAdapterParams = ethers.utils.solidityPack(["uint16", "uint256"], [1, 250000])
     const batchSizeLimit = 300
-    const defaultAdapterParams = ethers.utils.solidityPack(["uint16", "uint256"], [1, 200000])
 
-    let owner, warlock, lzEndpointMockA, lzEndpointMockB, LZEndpointMock, ONFT, ONFT_A, ONFT_B
+    let owner, warlock, lzEndpointMockA, lzEndpointMockB, LZEndpointMock, ONFT721A, ONFT721, onft721a_A, onft721_B
 
     before(async function () {
         owner = (await ethers.getSigners())[0]
         warlock = (await ethers.getSigners())[1]
         LZEndpointMock = await ethers.getContractFactory("LZEndpointMock")
-        ONFT = await ethers.getContractFactory("ONFT721Mock")
+        ONFT721A = await ethers.getContractFactory("ONFT721AMock")
+        ONFT721 = await ethers.getContractFactory("ONFT721Mock")
     })
 
     beforeEach(async function () {
         lzEndpointMockA = await LZEndpointMock.deploy(chainId_A)
         lzEndpointMockB = await LZEndpointMock.deploy(chainId_B)
 
-        // generate a proxy to allow it to go ONFT
-        ONFT_A = await ONFT.deploy(name, symbol, minGasToStore, lzEndpointMockA.address)
-        ONFT_B = await ONFT.deploy(name, symbol, minGasToStore, lzEndpointMockB.address)
+        onft721a_A = await ONFT721A.deploy(name, symbol, 150000, lzEndpointMockA.address)
+        onft721_B = await ONFT721.deploy(name, symbol, 150000, lzEndpointMockB.address)
 
         // wire the lz endpoints to guide msgs back and forth
-        lzEndpointMockA.setDestLzEndpoint(ONFT_B.address, lzEndpointMockB.address)
-        lzEndpointMockB.setDestLzEndpoint(ONFT_A.address, lzEndpointMockA.address)
+        lzEndpointMockA.setDestLzEndpoint(onft721_B.address, lzEndpointMockB.address)
+        lzEndpointMockB.setDestLzEndpoint(onft721a_A.address, lzEndpointMockA.address)
 
         // set each contracts source address so it can send to each other
-        await ONFT_A.setTrustedRemote(chainId_B, ethers.utils.solidityPack(["address", "address"], [ONFT_B.address, ONFT_A.address]))
-        await ONFT_B.setTrustedRemote(chainId_A, ethers.utils.solidityPack(["address", "address"], [ONFT_A.address, ONFT_B.address]))
+        await onft721a_A.setTrustedRemoteAddress(chainId_B, onft721_B.address)
+        await onft721_B.setTrustedRemoteAddress(chainId_A, onft721a_A.address)
 
-        // set batch size limit
-        await ONFT_A.setDstChainIdToBatchLimit(chainId_B, batchSizeLimit)
-        await ONFT_B.setDstChainIdToBatchLimit(chainId_A, batchSizeLimit)
-
-        // set min dst gas for swap
-        await ONFT_A.setMinDstGas(chainId_B, 1, 150000)
-        await ONFT_B.setMinDstGas(chainId_A, 1, 150000)
+        await onft721a_A.setMinDstGas(chainId_B, 1, 150000)
+        await onft721_B.setMinDstGas(chainId_A, 1, 150000)
     })
 
     it("sendFrom() - your own tokens", async function () {
-        const tokenId = 123
-        await ONFT_A.mint(owner.address, tokenId)
+        let tokenId = 1;
+        await onft721a_A.mint(2)
 
         // verify the owner of the token is on the source chain
-        expect(await ONFT_A.ownerOf(tokenId)).to.be.equal(owner.address)
+        expect(await onft721a_A.ownerOf(0)).to.be.equal(owner.address)
+        expect(await onft721a_A.ownerOf(1)).to.be.equal(owner.address)
 
         // token doesn't exist on other chain
-        await expect(ONFT_B.ownerOf(tokenId)).to.be.revertedWith("ERC721: invalid token ID")
+        await expect(onft721_B.ownerOf(tokenId)).to.be.revertedWith("ERC721: invalid token ID")
 
         // can transfer token on srcChain as regular erC721
-        await ONFT_A.transferFrom(owner.address, warlock.address, tokenId)
-        expect(await ONFT_A.ownerOf(tokenId)).to.be.equal(warlock.address)
+        await onft721a_A.transferFrom(owner.address, warlock.address, tokenId)
+        expect(await onft721a_A.ownerOf(tokenId)).to.be.equal(warlock.address)
 
-        // approve the proxy to swap your token
-        await ONFT_A.connect(warlock).approve(ONFT_A.address, tokenId)
+        // approve the contract to swap your token
+        await onft721a_A.connect(warlock).approve(onft721a_A.address, tokenId)
 
         // estimate nativeFees
-        let nativeFee = (await ONFT_A.estimateSendFee(chainId_B, warlock.address, tokenId, false, defaultAdapterParams)).nativeFee
+        let nativeFee = (await onft721a_A.estimateSendFee(chainId_B, owner.address, tokenId, false, defaultAdapterParams)).nativeFee
 
         // swaps token to other chain
-        await ONFT_A.connect(warlock).sendFrom(
+        await onft721a_A.connect(warlock).sendFrom(
             warlock.address,
             chainId_B,
             warlock.address,
@@ -79,19 +74,17 @@ describe("ONFT721: ", function () {
         )
 
         // token is burnt
-        expect(await ONFT_A.ownerOf(tokenId)).to.be.equal(ONFT_A.address)
+        expect(await onft721a_A.ownerOf(0)).to.be.equal(owner.address)
+        expect(await onft721a_A.ownerOf(tokenId)).to.be.equal(onft721a_A.address)
 
         // token received on the dst chain
-        expect(await ONFT_B.ownerOf(tokenId)).to.be.equal(warlock.address)
-
-        // estimate nativeFees
-        nativeFee = (await ONFT_B.estimateSendFee(chainId_A, warlock.address, tokenId, false, defaultAdapterParams)).nativeFee
+        expect(await onft721_B.ownerOf(tokenId)).to.be.equal(warlock.address)
 
         // can send to other onft contract eg. not the original nft contract chain
-        await ONFT_B.connect(warlock).sendFrom(
+        await onft721_B.connect(warlock).sendFrom(
             warlock.address,
             chainId_A,
-            warlock.address,
+            owner.address,
             tokenId,
             warlock.address,
             ethers.constants.AddressZero,
@@ -100,67 +93,62 @@ describe("ONFT721: ", function () {
         )
 
         // token is burned on the sending chain
-        expect(await ONFT_B.ownerOf(tokenId)).to.be.equal(ONFT_B.address)
+        expect(await onft721a_A.ownerOf(tokenId)).to.be.equal(owner.address)
+        expect(await onft721_B.ownerOf(tokenId)).to.be.equal(onft721_B.address)
     })
 
-    it("sendFrom() - reverts if not owner on non proxy chain", async function () {
-        const tokenId = 123
-        await ONFT_A.mint(owner.address, tokenId)
+    it("sendFrom() - reverts if not owner", async function () {
+        const tokenId = 0
+        await onft721a_A.mint(1)
 
-        // approve the proxy to swap your token
-        await ONFT_A.approve(ONFT_A.address, tokenId)
+        // approve the contract to swap your token
+        await onft721a_A.approve(onft721a_A.address, tokenId)
 
         // estimate nativeFees
-        let nativeFee = (await ONFT_A.estimateSendFee(chainId_B, owner.address, tokenId, false, defaultAdapterParams)).nativeFee
+        let nativeFee = (await onft721_B.estimateSendFee(chainId_B, owner.address, tokenId, false, defaultAdapterParams)).nativeFee
 
         // swaps token to other chain
-        await ONFT_A.sendFrom(owner.address, chainId_B, owner.address, tokenId, owner.address, ethers.constants.AddressZero, defaultAdapterParams, {
-            value: nativeFee,
-        })
+        await onft721a_A.sendFrom(owner.address, chainId_B, owner.address, tokenId, owner.address, ethers.constants.AddressZero, defaultAdapterParams, { value: nativeFee })
 
         // token received on the dst chain
-        expect(await ONFT_B.ownerOf(tokenId)).to.be.equal(owner.address)
+        expect(await onft721_B.ownerOf(tokenId)).to.be.equal(owner.address)
 
         // reverts because other address does not own it
         await expect(
-            ONFT_B.connect(warlock).sendFrom(
+            onft721_B.connect(warlock).sendFrom(
                 warlock.address,
                 chainId_A,
                 warlock.address,
                 tokenId,
                 warlock.address,
                 ethers.constants.AddressZero,
-                defaultAdapterParams
+                defaultAdapterParams,
+                { value: nativeFee }
             )
         ).to.be.revertedWith("ONFT721: send caller is not owner nor approved")
     })
 
     it("sendFrom() - on behalf of other user", async function () {
-        const tokenId = 123
-        await ONFT_A.mint(owner.address, tokenId)
+        const tokenId = 0
+        await onft721a_A.mint(1)
 
-        // approve the proxy to swap your token
-        await ONFT_A.approve(ONFT_A.address, tokenId)
+        // approve the contract to swap your token
+        await onft721a_A.approve(onft721a_A.address, tokenId)
 
         // estimate nativeFees
-        let nativeFee = (await ONFT_A.estimateSendFee(chainId_B, owner.address, tokenId, false, defaultAdapterParams)).nativeFee
+        let nativeFee = (await onft721_B.estimateSendFee(chainId_B, owner.address, tokenId, false, defaultAdapterParams)).nativeFee
 
         // swaps token to other chain
-        await ONFT_A.sendFrom(owner.address, chainId_B, owner.address, tokenId, owner.address, ethers.constants.AddressZero, defaultAdapterParams, {
-            value: nativeFee,
-        })
+        await onft721a_A.sendFrom(owner.address, chainId_B, owner.address, tokenId, owner.address, ethers.constants.AddressZero, defaultAdapterParams, { value: nativeFee })
 
         // token received on the dst chain
-        expect(await ONFT_B.ownerOf(tokenId)).to.be.equal(owner.address)
+        expect(await onft721_B.ownerOf(tokenId)).to.be.equal(owner.address)
 
         // approve the other user to send the token
-        await ONFT_B.approve(warlock.address, tokenId)
-
-        // estimate nativeFees
-        nativeFee = (await ONFT_B.estimateSendFee(chainId_A, warlock.address, tokenId, false, defaultAdapterParams)).nativeFee
+        await onft721_B.approve(warlock.address, tokenId)
 
         // sends across
-        await ONFT_B.connect(warlock).sendFrom(
+        await onft721_B.connect(warlock).sendFrom(
             owner.address,
             chainId_A,
             warlock.address,
@@ -172,123 +160,122 @@ describe("ONFT721: ", function () {
         )
 
         // token received on the dst chain
-        expect(await ONFT_A.ownerOf(tokenId)).to.be.equal(warlock.address)
+        expect(await onft721a_A.ownerOf(tokenId)).to.be.equal(warlock.address)
     })
 
     it("sendFrom() - reverts if contract is approved, but not the sending user", async function () {
-        const tokenId = 123
-        await ONFT_A.mint(owner.address, tokenId)
-
-        // approve the proxy to swap your token
-        await ONFT_A.approve(ONFT_A.address, tokenId)
-
-        // estimate nativeFees
-        let nativeFee = (await ONFT_A.estimateSendFee(chainId_B, owner.address, tokenId, false, defaultAdapterParams)).nativeFee
-
-        // swaps token to other chain
-        await ONFT_A.sendFrom(owner.address, chainId_B, owner.address, tokenId, owner.address, ethers.constants.AddressZero, defaultAdapterParams, {
-            value: nativeFee,
-        })
-
-        // token received on the dst chain
-        expect(await ONFT_B.ownerOf(tokenId)).to.be.equal(owner.address)
+        const tokenId = 0
+        await onft721a_A.mint(1)
 
         // approve the contract to swap your token
-        await ONFT_B.approve(ONFT_B.address, tokenId)
+        await onft721a_A.approve(onft721a_A.address, tokenId)
+
+        // estimate nativeFees
+        let nativeFee = (await onft721_B.estimateSendFee(chainId_B, owner.address, tokenId, false, defaultAdapterParams)).nativeFee
+
+        // swaps token to other chain
+        await onft721a_A.sendFrom(owner.address, chainId_B, owner.address, tokenId, owner.address, ethers.constants.AddressZero, defaultAdapterParams, { value: nativeFee })
+
+        // token received on the dst chain
+        expect(await onft721_B.ownerOf(tokenId)).to.be.equal(owner.address)
+
+        // approve the contract to swap your token
+        await onft721_B.approve(onft721_B.address, tokenId)
 
         // reverts because contract is approved, not the user
         await expect(
-            ONFT_B.connect(warlock).sendFrom(
+            onft721_B.connect(warlock).sendFrom(
                 owner.address,
                 chainId_A,
                 warlock.address,
                 tokenId,
                 warlock.address,
                 ethers.constants.AddressZero,
-                defaultAdapterParams
+                defaultAdapterParams,
+                { value: nativeFee }
             )
         ).to.be.revertedWith("ONFT721: send caller is not owner nor approved")
     })
 
-    it("sendFrom() - reverts if not approved on non proxy chain", async function () {
-        const tokenId = 123
-        await ONFT_A.mint(owner.address, tokenId)
+    it("sendFrom() - reverts if not approved", async function () {
+        const tokenId = 0
+        await onft721a_A.mint(1)
 
-        // approve the proxy to swap your token
-        await ONFT_A.approve(ONFT_A.address, tokenId)
+        // approve the contract to swap your token
+        await onft721a_A.approve(onft721a_A.address, tokenId)
 
         // estimate nativeFees
-        let nativeFee = (await ONFT_A.estimateSendFee(chainId_B, owner.address, tokenId, false, defaultAdapterParams)).nativeFee
+        let nativeFee = (await onft721_B.estimateSendFee(chainId_B, owner.address, tokenId, false, defaultAdapterParams)).nativeFee
 
         // swaps token to other chain
-        await ONFT_A.sendFrom(owner.address, chainId_B, owner.address, tokenId, owner.address, ethers.constants.AddressZero, defaultAdapterParams, {
-            value: nativeFee,
-        })
+        await onft721a_A.sendFrom(owner.address, chainId_B, owner.address, tokenId, owner.address, ethers.constants.AddressZero, defaultAdapterParams, { value: nativeFee })
 
         // token received on the dst chain
-        expect(await ONFT_B.ownerOf(tokenId)).to.be.equal(owner.address)
+        expect(await onft721_B.ownerOf(tokenId)).to.be.equal(owner.address)
 
         // reverts because user is not approved
         await expect(
-            ONFT_B.connect(warlock).sendFrom(
+            onft721_B.connect(warlock).sendFrom(
                 owner.address,
                 chainId_A,
                 warlock.address,
                 tokenId,
                 warlock.address,
                 ethers.constants.AddressZero,
-                defaultAdapterParams
+                defaultAdapterParams,
+                { value: nativeFee }
             )
         ).to.be.revertedWith("ONFT721: send caller is not owner nor approved")
     })
 
     it("sendFrom() - reverts if sender does not own token", async function () {
-        const tokenIdA = 123
-        const tokenIdB = 456
-        // mint to both owners
-        await ONFT_A.mint(owner.address, tokenIdA)
-        await ONFT_A.mint(warlock.address, tokenIdB)
+        const tokenIdA = 0
+        await onft721a_A.mint(1)
 
         // approve owner.address to transfer, but not the other
-        await ONFT_A.setApprovalForAll(ONFT_A.address, true)
+        await onft721a_A.setApprovalForAll(onft721a_A.address, true)
+
+        // estimate nativeFees
+        let nativeFee = (await onft721a_A.estimateSendFee(chainId_B, owner.address, tokenIdA, false, defaultAdapterParams)).nativeFee
 
         await expect(
-            ONFT_A.connect(warlock).sendFrom(
+            onft721a_A.connect(warlock).sendFrom(
                 warlock.address,
                 chainId_B,
                 warlock.address,
                 tokenIdA,
                 warlock.address,
                 ethers.constants.AddressZero,
-                defaultAdapterParams
+                defaultAdapterParams,
+                { value: nativeFee }
             )
-        ).to.be.revertedWith("ONFT721: send caller is not owner nor approved")
+        ).to.be.revertedWith("TransferFromIncorrectOwner()")
+
         await expect(
-            ONFT_A.connect(warlock).sendFrom(
+            onft721a_A.connect(warlock).sendFrom(
                 warlock.address,
                 chainId_B,
                 owner.address,
                 tokenIdA,
                 owner.address,
                 ethers.constants.AddressZero,
-                defaultAdapterParams
+                defaultAdapterParams,
+                { value: nativeFee }
             )
-        ).to.be.revertedWith("ONFT721: send caller is not owner nor approved")
+        ).to.be.revertedWith("TransferFromIncorrectOwner()")
     })
 
     it("sendBatchFrom()", async function () {
-        await ONFT_A.setMinGasToTransferAndStore(400000)
-        await ONFT_B.setMinGasToTransferAndStore(400000)
-
-        const tokenIds = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-
+        await onft721a_A.setMinGasToTransferAndStore(400000)
+        await onft721_B.setMinGasToTransferAndStore(400000)
+        await onft721a_A.setDstChainIdToBatchLimit(chainId_B, batchSizeLimit)
+        await onft721_B.setDstChainIdToBatchLimit(chainId_A, batchSizeLimit)
+        const tokenIds = [0,1,2,3,4,5,6,7,8,9]
         // mint to owner
-        for (let tokenId of tokenIds) {
-            await ONFT_A.mint(warlock.address, tokenId)
-        }
+        await onft721a_A.connect(warlock).mint(10)
 
         // approve owner.address to transfer
-        await ONFT_A.connect(warlock).setApprovalForAll(ONFT_A.address, true)
+        await onft721a_A.connect(warlock).setApprovalForAll(onft721a_A.address, true)
 
         // expected event params
         const payload = ethers.utils.defaultAbiCoder.encode(["bytes", "uint[]"], [warlock.address, tokenIds])
@@ -297,10 +284,10 @@ describe("ONFT721: ", function () {
         let adapterParams = ethers.utils.solidityPack(["uint16", "uint256"], [1, 200000])
 
         // estimate nativeFees
-        let nativeFee = (await ONFT_A.estimateSendBatchFee(chainId_B, warlock.address, tokenIds, false, defaultAdapterParams)).nativeFee
+        let nativeFee = (await onft721a_A.estimateSendBatchFee(chainId_B, warlock.address, tokenIds, false, defaultAdapterParams)).nativeFee
 
         // initiate batch transfer
-        await expect(ONFT_A.connect(warlock).sendBatchFrom(
+        await expect(onft721a_A.connect(warlock).sendBatchFrom(
             warlock.address,
             chainId_B,
             warlock.address,
@@ -309,12 +296,12 @@ describe("ONFT721: ", function () {
             ethers.constants.AddressZero,
             adapterParams, // TODO might need to change this
             { value: nativeFee }
-        )).to.emit(ONFT_B, "CreditStored").withArgs(hashedPayload, payload)
+        )).to.emit(onft721_B, "CreditStored").withArgs(hashedPayload, payload)
 
         // only partial amount of tokens has been sent, the rest have been stored as a credit
         let creditedIdsA = []
         for (let tokenId of tokenIds) {
-            let owner = await ONFT_B.rawOwnerOf(tokenId)
+            let owner = await onft721_B.rawOwnerOf(tokenId)
             if (owner == ethers.constants.AddressZero) {
                 creditedIdsA.push(tokenId)
             } else {
@@ -323,11 +310,11 @@ describe("ONFT721: ", function () {
         }
 
         // clear the rest of the credits
-        await expect(ONFT_B.clearCredits(payload)).to.emit(ONFT_B, "CreditCleared").withArgs(hashedPayload)
+        await expect(onft721_B.clearCredits(payload)).to.emit(onft721_B, "CreditCleared").withArgs(hashedPayload)
 
         let creditedIdsB = []
         for (let tokenId of creditedIdsA) {
-            let owner = await ONFT_B.rawOwnerOf(tokenId)
+            let owner = await onft721_B.rawOwnerOf(tokenId)
             if (owner == ethers.constants.AddressZero) {
                 creditedIdsB.push(tokenId)
             } else {
@@ -339,26 +326,28 @@ describe("ONFT721: ", function () {
         expect(creditedIdsB.length).to.be.equal(0)
 
         // should revert because payload is no longer valid
-        await expect(ONFT_B.clearCredits(payload)).to.be.revertedWith("ONFT721: no credits stored")
+        await expect(onft721_B.clearCredits(payload)).to.be.revertedWith("ONFT721: no credits stored")
     })
 
     it("sendBatchFrom() - large batch", async function () {
-        await ONFT_A.setMinGasToTransferAndStore(400000)
-        await ONFT_B.setMinGasToTransferAndStore(400000)
+        await onft721a_A.setMinGasToTransferAndStore(400000)
+        await onft721_B.setMinGasToTransferAndStore(400000)
+        await onft721a_A.setDstChainIdToBatchLimit(chainId_B, batchSizeLimit)
+        await onft721_B.setDstChainIdToBatchLimit(chainId_A, batchSizeLimit)
 
         const tokenIds = []
 
-        for (let i = 1; i <= 300; i++) {
+        for (let i = 0; i < 300; i++) {
             tokenIds.push(i)
         }
 
         // mint to owner
         for (let tokenId of tokenIds) {
-            await ONFT_A.mint(warlock.address, tokenId)
+            await onft721a_A.connect(warlock).mint(1)
         }
 
         // approve owner.address to transfer
-        await ONFT_A.connect(warlock).setApprovalForAll(ONFT_A.address, true)
+        await onft721a_A.connect(warlock).setApprovalForAll(onft721a_A.address, true)
 
         // expected event params
         const payload = ethers.utils.defaultAbiCoder.encode(["bytes", "uint[]"], [warlock.address, tokenIds])
@@ -367,10 +356,10 @@ describe("ONFT721: ", function () {
         let adapterParams = ethers.utils.solidityPack(["uint16", "uint256"], [1, 400000])
 
         // estimate nativeFees
-        let nativeFee = (await ONFT_A.estimateSendBatchFee(chainId_B, warlock.address, tokenIds, false, adapterParams)).nativeFee
+        let nativeFee = (await onft721a_A.estimateSendBatchFee(chainId_B, warlock.address, tokenIds, false, adapterParams)).nativeFee
 
         // initiate batch transfer
-        await expect(ONFT_A.connect(warlock).sendBatchFrom(
+        await expect(onft721a_A.connect(warlock).sendBatchFrom(
             warlock.address,
             chainId_B,
             warlock.address,
@@ -379,12 +368,12 @@ describe("ONFT721: ", function () {
             ethers.constants.AddressZero,
             adapterParams, // TODO might need to change this
             { value: nativeFee }
-        )).to.emit(ONFT_B, "CreditStored").withArgs(hashedPayload, payload)
+        )).to.emit(onft721_B, "CreditStored").withArgs(hashedPayload, payload)
 
         // only partial amount of tokens has been sent, the rest have been stored as a credit
         let creditedIdsA = []
         for (let tokenId of tokenIds) {
-            let owner = await ONFT_B.rawOwnerOf(tokenId)
+            let owner = await onft721_B.rawOwnerOf(tokenId)
             if (owner == ethers.constants.AddressZero) {
                 creditedIdsA.push(tokenId)
             } else {
@@ -395,13 +384,13 @@ describe("ONFT721: ", function () {
         // console.log("Number of tokens credited: ", creditedIdsA.length)
 
         // clear the rest of the credits
-        let tx = await(await ONFT_B.clearCredits(payload)).wait()
+        let tx = await(await onft721_B.clearCredits(payload)).wait()
 
         // console.log("Total gasUsed: ", tx.gasUsed.toString())
 
         let creditedIdsB = []
         for (let tokenId of creditedIdsA) {
-            let owner = await ONFT_B.rawOwnerOf(tokenId)
+            let owner = await onft721_B.rawOwnerOf(tokenId)
             if (owner == ethers.constants.AddressZero) {
                 creditedIdsB.push(tokenId)
             } else {
@@ -415,6 +404,6 @@ describe("ONFT721: ", function () {
         expect(creditedIdsB.length).to.be.equal(0)
 
         // should revert because payload is no longer valid
-        await expect(ONFT_B.clearCredits(payload)).to.be.revertedWith("ONFT721: no credits stored")
+        await expect(onft721_B.clearCredits(payload)).to.be.revertedWith("ONFT721: no credits stored")
     })
 })

--- a/test/contracts/onft/ONFT721A.test.js
+++ b/test/contracts/onft/ONFT721A.test.js
@@ -326,7 +326,7 @@ describe("ONFT721A: ", function () {
         expect(creditedIdsB.length).to.be.equal(0)
 
         // should revert because payload is no longer valid
-        await expect(onft721_B.clearCredits(payload)).to.be.revertedWith("ONFT721: no credits stored")
+        await expect(onft721_B.clearCredits(payload)).to.be.revertedWith("no credits stored")
     })
 
     it("sendBatchFrom() - large batch", async function () {
@@ -404,6 +404,6 @@ describe("ONFT721A: ", function () {
         expect(creditedIdsB.length).to.be.equal(0)
 
         // should revert because payload is no longer valid
-        await expect(onft721_B.clearCredits(payload)).to.be.revertedWith("ONFT721: no credits stored")
+        await expect(onft721_B.clearCredits(payload)).to.be.revertedWith("no credits stored")
     })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3339,6 +3339,11 @@ env-paths@^2.2.0:
   resolved "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz"
   integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
 
+erc721a@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/erc721a/-/erc721a-4.2.3.tgz#ca6469b0e54afb0f614272c2147dc4cb49ff223f"
+  integrity sha512-0deF0hOOK1XI1Vxv3NKDh2E9sgzRlENuOoexjXRJIRfYCsLlqi9ejl2RF6Wcd9HfH0ldqC03wleQ2WDjxoOUvA==
+
 errno@~0.1.1:
   version "0.1.8"
   resolved "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz"


### PR DESCRIPTION
Adding in DistributeONFT721 and ONFT721A

DistributeONFT721 allows for contracts to distribute unused token ids to other chains. Default is set to 10,000 token ids w/ 2500 tokens on 4 chains. Uses unit[] to keep track of token ids on the current chain. Each unit in the array uses 250 bits of its allotted 256 bits to represent token ids. If the bit is set to 1 then that token id can be minted. Token Ids are defined by where they are in the token Ids array. 
 
ONFT721A implements ERC721A. This allows the ONFT to utilize the gas savings of minting multiple NFT's at once(ERC721A). But this contract can only be deployed on one chain and must be the first minter of each token id. This is because ERC721A does not have the ability to mint a specific token id. The other chains must have ONFT721 deployed.