### PR TITLE
Fixed params missing, filled with default minGasToTransferAndStore.

### DIFF
--- a/constants/onftArgs.json
+++ b/constants/onftArgs.json
@@ -1,14 +1,17 @@
 {
   "bsc-testnet": {
     "startMintId": 1,
-    "endMintId": 10
+    "endMintId": 10,
+    "minGas": 200000
   },
   "fuji": {
     "startMintId": 11,
-    "endMintId": 20
+    "endMintId": 20,
+    "minGas": 200000
   },
   "goerli": {
     "startMintId": 21,
-    "endMintId": 30
+    "endMintId": 30,
+    "minGas": 200000
   }
 }

--- a/deploy/ExampleUniversalONFT721.js
+++ b/deploy/ExampleUniversalONFT721.js
@@ -13,7 +13,7 @@ module.exports = async function ({ deployments, getNamedAccounts }) {
 
     await deploy("ExampleUniversalONFT721", {
         from: deployer,
-        args: [lzEndpointAddress, onftArgs.startMintId, onftArgs.endMintId],
+        args: [Number(onftArgs.minGas), lzEndpointAddress, onftArgs.startMintId, onftArgs.endMintId],
         log: true,
         waitConfirmations: 1,
     })


### PR DESCRIPTION
> constructor(string memory _name, string memory _symbol, uint256 _minGasToTransfer, address _layerZeroEndpoint, uint _startMintId, uint _endMintId)

The _minGasToTransfer parameter is required here, but the code is missing this parameter. Additionally, filling in default initial parameters.