### PR TITLE
Fix ExampleUniversalONFT721 and ONFT721 deploy error with minGasToStore

### DIFF
--- a/deploy/ExampleUniversalONFT721.js
+++ b/deploy/ExampleUniversalONFT721.js
@@ -4,6 +4,7 @@ const ONFT_ARGS = require("../constants/onftArgs.json")
 module.exports = async function ({ deployments, getNamedAccounts }) {
     const { deploy } = deployments
     const { deployer } = await getNamedAccounts()
+    const minGasToStore = 150000
     console.log(`>>> your address: ${deployer}`)
 
     const lzEndpointAddress = LZ_ENDPOINTS[hre.network.name]
@@ -13,7 +14,7 @@ module.exports = async function ({ deployments, getNamedAccounts }) {
 
     await deploy("ExampleUniversalONFT721", {
         from: deployer,
-        args: [lzEndpointAddress, onftArgs.startMintId, onftArgs.endMintId],
+        args: [minGasToStore, lzEndpointAddress, onftArgs.startMintId, onftArgs.endMintId],
         log: true,
         waitConfirmations: 1,
     })

--- a/deploy/ONFT721.js
+++ b/deploy/ONFT721.js
@@ -4,6 +4,7 @@ const ONFT_ARGS = require("../constants/onftArgs.json")
 module.exports = async function ({ deployments, getNamedAccounts }) {
     const { deploy } = deployments
     const { deployer } = await getNamedAccounts()
+    const minGasToStore = 150000
     console.log(`>>> your address: ${deployer}`)
 
     const lzEndpointAddress = LZ_ENDPOINTS[hre.network.name]
@@ -13,7 +14,7 @@ module.exports = async function ({ deployments, getNamedAccounts }) {
 
     await deploy("ONFT721", {
         from: deployer,
-        args: [lzEndpointAddress, onftArgs.startMintId, onftArgs.endMintId],
+        args: [minGasToStore, lzEndpointAddress, onftArgs.startMintId, onftArgs.endMintId],
         log: true,
         waitConfirmations: 1,
     })


### PR DESCRIPTION
```solidity
constructor(uint256 _minGasToStore, address _layerZeroEndpoint, uint _startMintId, uint _endMintId)
```

_minGasToStore is required here but is missing in the deploy scripts.

Fixes issue https://github.com/LayerZero-Labs/solidity-examples/issues/74