### PR TITLE
Adding in NativeOFTWithFee

### DIFF
--- a/contracts/token/oft/v2/fee/NativeOFTWithFee.sol
+++ b/contracts/token/oft/v2/fee/NativeOFTWithFee.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "./OFTWithFee.sol";
+
+contract NativeOFTWithFee is OFTWithFee, ReentrancyGuard {
+
+    event Deposit(address indexed _dst, uint _amount);
+    event Withdrawal(address indexed _src, uint _amount);
+
+    constructor(string memory _name, string memory _symbol, uint8 _sharedDecimals, address _lzEndpoint) OFTWithFee(_name, _symbol, _sharedDecimals, _lzEndpoint) {}
+
+    function deposit() public payable {
+        _mint(msg.sender, msg.value);
+        emit Deposit(msg.sender, msg.value);
+    }
+
+    function withdraw(uint _amount) external nonReentrant {
+        require(balanceOf(msg.sender) >= _amount, "NativeOFTWithFee: Insufficient balance.");
+        _burn(msg.sender, _amount);
+        (bool success, ) = msg.sender.call{value: _amount}("");
+        require(success, "NativeOFTWithFee: failed to unwrap");
+        emit Withdrawal(msg.sender, _amount);
+    }
+
+    function _send(address _from, uint16 _dstChainId, bytes32 _toAddress, uint _amount, address payable _refundAddress, address _zroPaymentAddress, bytes memory _adapterParams) internal virtual override returns (uint amount) {
+        _checkAdapterParams(_dstChainId, PT_SEND, _adapterParams, NO_EXTRA_GAS);
+
+        (amount,) = _removeDust(_amount);
+        require(amount > 0, "NativeOFTWithFee: amount too small");
+        uint messageFee = _debitFromNative(_from, amount);
+
+        bytes memory lzPayload = _encodeSendPayload(_toAddress, _ld2sd(amount));
+        _lzSend(_dstChainId, lzPayload, _refundAddress, _zroPaymentAddress, _adapterParams, messageFee);
+
+        emit SendToChain(_dstChainId, _from, _toAddress, amount);
+    }
+
+    function _sendAndCall(address _from, uint16 _dstChainId, bytes32 _toAddress, uint _amount, bytes memory _payload, uint64 _dstGasForCall, address payable _refundAddress, address _zroPaymentAddress, bytes memory _adapterParams) internal virtual override returns (uint amount) {
+        _checkAdapterParams(_dstChainId, PT_SEND_AND_CALL, _adapterParams, _dstGasForCall);
+
+        (amount,) = _removeDust(_amount);
+        require(amount > 0, "NativeOFTWithFee: amount too small");
+        uint messageFee = _debitFromNative(_from, amount);
+
+        // encode the msg.sender into the payload instead of _from
+        bytes memory lzPayload = _encodeSendAndCallPayload(msg.sender, _toAddress, _ld2sd(amount), _payload, _dstGasForCall);
+        _lzSend(_dstChainId, lzPayload, _refundAddress, _zroPaymentAddress, _adapterParams, messageFee);
+
+        emit SendToChain(_dstChainId, _from, _toAddress, amount);
+    }
+
+    function _debitFromNative(address _from, uint _amount) internal returns (uint messageFee) {
+        messageFee = msg.sender == _from ? _debitMsgSender(_amount) : _debitMsgFrom(_from, _amount);
+    }
+
+    function _debitMsgSender(uint _amount) internal returns (uint messageFee) {
+        uint msgSenderBalance = balanceOf(msg.sender);
+
+        if (msgSenderBalance < _amount) {
+            require(msgSenderBalance + msg.value >= _amount, "NativeOFTWithFee: Insufficient msg.value");
+
+            // user can cover difference with additional msg.value ie. wrapping
+            uint mintAmount = _amount - msgSenderBalance;
+            _mint(address(msg.sender), mintAmount);
+
+            // update the messageFee to take out mintAmount
+            messageFee = msg.value - mintAmount;
+        } else {
+            messageFee = msg.value;
+        }
+
+        _transfer(msg.sender, address(this), _amount);
+        return messageFee;
+    }
+
+    function _debitMsgFrom(address _from, uint _amount) internal returns (uint messageFee) {
+        uint msgFromBalance = balanceOf(_from);
+
+        if (msgFromBalance < _amount) {
+            require(msgFromBalance + msg.value >= _amount, "NativeOFTWithFee: Insufficient msg.value");
+
+            // user can cover difference with additional msg.value ie. wrapping
+            uint mintAmount = _amount - msgFromBalance;
+            _mint(address(msg.sender), mintAmount);
+
+            // transfer the differential amount to the contract
+            _transfer(msg.sender, address(this), mintAmount);
+
+            // overwrite the _amount to take the rest of the balance from the _from address
+            _amount = msgFromBalance;
+
+            // update the messageFee to take out mintAmount
+            messageFee = msg.value - mintAmount;
+        } else {
+            messageFee = msg.value;
+        }
+
+        _spendAllowance(_from, msg.sender, _amount);
+        _transfer(_from, address(this), _amount);
+        return messageFee;
+    }
+
+    function _creditTo(uint16, address _toAddress, uint _amount) internal override returns(uint) {
+        _burn(address(this), _amount);
+        (bool success, ) = _toAddress.call{value: _amount}("");
+        require(success, "NativeOFTWithFee: failed to _creditTo");
+        return _amount;
+    }
+
+    receive() external payable {
+        deposit();
+    }
+}

--- a/test/contracts/oft/v2/NativeOFTWithFee.test.js
+++ b/test/contracts/oft/v2/NativeOFTWithFee.test.js
@@ -1,0 +1,467 @@
+const { expect } = require("chai")
+const { ethers } = require("hardhat")
+
+describe("NativeOFTWithFee: ", function () {
+    const localChainId = 1
+    const remoteChainId = 2
+    const name = "NativeOFTWithFee"
+    const symbol = "NOFT"
+    const sharedDecimals = 6
+
+    let owner, alice, bob, localEndpoint, remoteEndpoint, nativeOFTWithFee, remoteOFTWithFee, LZEndpointMock, NativeOFTWithFee, OFTWithFee, ownerAddressBytes32
+
+    before(async function () {
+        [owner, alice, bob] = await ethers.getSigners()
+        LZEndpointMock = await ethers.getContractFactory("LZEndpointMock")
+        NativeOFTWithFee = await ethers.getContractFactory("NativeOFTWithFee")
+        OFTWithFee = await ethers.getContractFactory("OFTWithFee")
+    })
+
+    beforeEach(async function () {
+        localEndpoint = await LZEndpointMock.deploy(localChainId)
+        remoteEndpoint = await LZEndpointMock.deploy(remoteChainId)
+
+        //------  deploy: base & other chain  -------------------------------------------------------
+        // create two NativeOFTWithFee instances. both tokens have the same name and symbol on each chain
+        // 1. base chain
+        // 2. other chain
+        nativeOFTWithFee = await NativeOFTWithFee.deploy(name, symbol, sharedDecimals, localEndpoint.address)
+        remoteOFTWithFee = await OFTWithFee.deploy(name, symbol, sharedDecimals, remoteEndpoint.address)
+
+        // internal bookkeeping for endpoints (not part of a real deploy, just for this test)
+        await localEndpoint.setDestLzEndpoint(remoteOFTWithFee.address, remoteEndpoint.address)
+        await remoteEndpoint.setDestLzEndpoint(nativeOFTWithFee.address, localEndpoint.address)
+
+        //------  setTrustedRemote(s) -------------------------------------------------------
+        // for each OFTV2, setTrustedRemote to allow it to receive from the remote OFTV2 contract.
+        // Note: This is sometimes referred to as the "wire-up" process.
+        // set each contracts source address so it can send to each other
+        await nativeOFTWithFee.setTrustedRemoteAddress(remoteChainId, remoteOFTWithFee.address)
+        await remoteOFTWithFee.setTrustedRemoteAddress(localChainId, nativeOFTWithFee.address)
+
+        ownerAddressBytes32 = ethers.utils.defaultAbiCoder.encode(["address"], [owner.address])
+    })
+
+    it("sendFrom() - tokens from main to other chain using default", async function () {
+        expect(await ethers.provider.getBalance(localEndpoint.address)).to.be.equal(ethers.utils.parseEther("0"))
+
+        // ensure they're both allocated initial amounts
+        let aliceBalance = await ethers.provider.getBalance(alice.address)
+        expect(await nativeOFTWithFee.balanceOf(owner.address)).to.equal(0)
+        expect(await remoteOFTWithFee.balanceOf(owner.address)).to.equal(0)
+        expect(await ethers.provider.getBalance(nativeOFTWithFee.address)).to.equal(0)
+
+        let depositAmount = ethers.utils.parseEther("7")
+        await nativeOFTWithFee.deposit({ value: depositAmount })
+
+        expect(await nativeOFTWithFee.balanceOf(owner.address)).to.equal(depositAmount)
+        expect(await ethers.provider.getBalance(nativeOFTWithFee.address)).to.be.equal(depositAmount)
+
+        let leftOverAmount = ethers.utils.parseEther("0")
+        let totalAmount = ethers.utils.parseEther("8")
+
+        // estimate nativeFees
+        let nativeFee = (await nativeOFTWithFee.estimateSendFee(remoteChainId, ownerAddressBytes32, totalAmount, false, "0x")).nativeFee
+        expect(await ethers.provider.getBalance(localEndpoint.address)).to.be.equal(ethers.utils.parseEther("0"))
+        await nativeOFTWithFee.sendFrom(
+            owner.address,
+            remoteChainId, // destination chainId
+            ownerAddressBytes32, // destination address to send tokens to
+            totalAmount, // quantity of tokens to send (in units of wei)
+            totalAmount, // quantity of tokens to send (in units of wei)
+            [owner.address, ethers.constants.AddressZero, "0x"],
+            { value: nativeFee.add(totalAmount.sub(depositAmount)) } // pass a msg.value to pay the LayerZero message fee
+        )
+
+        // expect(await ethers.provider.getBalance(owner.address)).to.be.equal(ownerBalance.sub(messageFee).sub(transFee).sub(depositAmount))
+        expect(await ethers.provider.getBalance(nativeOFTWithFee.address)).to.be.equal(totalAmount)
+        expect(await ethers.provider.getBalance(localEndpoint.address)).to.be.equal(nativeFee) // collects
+        expect(await nativeOFTWithFee.balanceOf(nativeOFTWithFee.address)).to.be.equal(totalAmount)
+        expect(await nativeOFTWithFee.balanceOf(owner.address)).to.be.equal(leftOverAmount)
+        expect(await remoteOFTWithFee.balanceOf(owner.address)).to.be.equal(totalAmount)
+
+        let ownerBalance2 = await ethers.provider.getBalance(owner.address)
+
+        const aliceAddressBytes32 = ethers.utils.defaultAbiCoder.encode(["address"], [alice.address])
+        // estimate nativeFees
+        nativeFee = (await nativeOFTWithFee.estimateSendFee(localChainId, aliceAddressBytes32, totalAmount, false, "0x")).nativeFee
+        await remoteOFTWithFee.sendFrom(
+            owner.address,
+            localChainId, // destination chainId
+            aliceAddressBytes32, // destination address to send tokens to
+            totalAmount, // quantity of tokens to send (in units of wei)
+            totalAmount, // quantity of tokens to send (in units of wei)
+            [owner.address, ethers.constants.AddressZero, "0x"],
+            { value: nativeFee.add(totalAmount) } // pass a msg.value to pay the LayerZero message fee
+        )
+
+        let transFee = ownerBalance2.sub(await ethers.provider.getBalance(owner.address)).sub(nativeFee)
+        expect(await ethers.provider.getBalance(alice.address)).to.be.equal(aliceBalance.add(totalAmount))
+        expect(await ethers.provider.getBalance(owner.address)).to.be.equal(ownerBalance2.sub(nativeFee).sub(transFee))
+        expect(await nativeOFTWithFee.balanceOf(owner.address)).to.equal(leftOverAmount)
+        expect(await remoteOFTWithFee.balanceOf(owner.address)).to.equal(0)
+    })
+
+    it("sendFrom() w/ fee change - tokens from main to other chain", async function () {
+        expect(await ethers.provider.getBalance(localEndpoint.address)).to.be.equal(ethers.utils.parseEther("0"))
+
+        // set default fee to 50%
+        await nativeOFTWithFee.setDefaultFeeBp(5000)
+        await nativeOFTWithFee.setFeeOwner(bob.address)
+
+        // ensure they're both allocated initial amounts
+        expect(await nativeOFTWithFee.balanceOf(owner.address)).to.equal(0)
+        expect(await remoteOFTWithFee.balanceOf(owner.address)).to.equal(0)
+        expect(await ethers.provider.getBalance(nativeOFTWithFee.address)).to.equal(0)
+
+        let depositAmount = ethers.utils.parseEther("7")
+        await nativeOFTWithFee.deposit({ value: depositAmount })
+
+        expect(await nativeOFTWithFee.balanceOf(owner.address)).to.equal(depositAmount)
+        expect(await ethers.provider.getBalance(nativeOFTWithFee.address)).to.be.equal(depositAmount)
+
+        let leftOverAmount = ethers.utils.parseEther("0")
+        let totalAmount = ethers.utils.parseEther("8")
+
+        // estimate nativeFees
+        let nativeFee = (await nativeOFTWithFee.estimateSendFee(remoteChainId, ownerAddressBytes32, totalAmount, false, "0x")).nativeFee
+        expect(await ethers.provider.getBalance(localEndpoint.address)).to.be.equal(ethers.utils.parseEther("0"))
+        await expect(
+            nativeOFTWithFee.sendFrom(
+                owner.address,
+                remoteChainId, // destination chainId
+                ownerAddressBytes32, // destination address to send tokens to
+                totalAmount, // quantity of tokens to send (in units of wei)
+                totalAmount, // quantity of tokens to send (in units of wei)
+                [owner.address, ethers.constants.AddressZero, "0x"],
+                { value: nativeFee.add(totalAmount.sub(depositAmount)) } // pass a msg.value to pay the LayerZero message fee
+            )
+        ).to.be.revertedWith("BaseOFTWithFee: amount is less than minAmount")
+
+        expect(await ethers.provider.getBalance(nativeOFTWithFee.address)).to.be.equal(depositAmount)
+        expect(await ethers.provider.getBalance(localEndpoint.address)).to.be.equal(0)
+        expect(await nativeOFTWithFee.balanceOf(nativeOFTWithFee.address)).to.be.equal(0)
+        expect(await nativeOFTWithFee.balanceOf(owner.address)).to.be.equal(depositAmount)
+        expect(await remoteOFTWithFee.balanceOf(owner.address)).to.be.equal(0)
+
+        const aliceAddressBytes32 = ethers.utils.defaultAbiCoder.encode(["address"], [alice.address])
+        // estimate nativeFees
+        let fee = await nativeOFTWithFee.quoteOFTFee(remoteChainId, totalAmount)
+        nativeFee = (await nativeOFTWithFee.estimateSendFee(remoteChainId, aliceAddressBytes32, totalAmount, false, "0x")).nativeFee
+        await nativeOFTWithFee.sendFrom(
+            owner.address,
+            remoteChainId, // destination chainId
+            aliceAddressBytes32, // destination address to send tokens to
+            totalAmount, // quantity of tokens to send (in units of wei)
+            totalAmount.sub(fee), // quantity of tokens to send (in units of wei)
+            [owner.address, ethers.constants.AddressZero, "0x"],
+            { value: nativeFee.add(totalAmount.sub(depositAmount)) } // pass a msg.value to pay the LayerZero message fee
+        )
+        expect(await ethers.provider.getBalance(nativeOFTWithFee.address)).to.be.equal(totalAmount)
+        expect(await ethers.provider.getBalance(localEndpoint.address)).to.be.equal(nativeFee) // collects
+        expect(await nativeOFTWithFee.balanceOf(owner.address)).to.be.equal(leftOverAmount)
+        expect(await nativeOFTWithFee.balanceOf(alice.address)).to.be.equal(leftOverAmount)
+        expect(await nativeOFTWithFee.balanceOf(bob.address)).to.be.equal(fee)
+        expect(await nativeOFTWithFee.balanceOf(nativeOFTWithFee.address)).to.be.equal(totalAmount.sub(fee))
+    })
+
+    it("quote oft fee", async function () {
+        // default fee 0%
+        expect(await nativeOFTWithFee.quoteOFTFee(1, 10000)).to.be.equal(0)
+
+        // change default fee to 10%
+        await nativeOFTWithFee.setDefaultFeeBp(1000)
+        expect(await nativeOFTWithFee.quoteOFTFee(1, 10000)).to.be.equal(1000)
+
+        // change fee to 20% for chain 2
+        await nativeOFTWithFee.setFeeBp(2, true, 2000)
+        expect(await nativeOFTWithFee.quoteOFTFee(1, 10000)).to.be.equal(1000)
+        expect(await nativeOFTWithFee.quoteOFTFee(2, 10000)).to.be.equal(2000)
+
+        // change fee to 0% for chain 2
+        await nativeOFTWithFee.setFeeBp(2, true, 0)
+        expect(await nativeOFTWithFee.quoteOFTFee(1, 10000)).to.be.equal(1000)
+        expect(await nativeOFTWithFee.quoteOFTFee(2, 10000)).to.be.equal(0)
+
+        // disable fee for chain 2
+        await nativeOFTWithFee.setFeeBp(2, false, 0)
+        expect(await nativeOFTWithFee.quoteOFTFee(1, 10000)).to.be.equal(1000)
+        expect(await nativeOFTWithFee.quoteOFTFee(2, 10000)).to.be.equal(1000)
+    })
+
+    it("sendFrom() - with enough native", async function () {
+        // ensure they're both allocated initial amounts
+        expect(await nativeOFTWithFee.balanceOf(owner.address)).to.equal(0)
+        expect(await remoteOFTWithFee.balanceOf(owner.address)).to.equal(0)
+        expect(await ethers.provider.getBalance(nativeOFTWithFee.address)).to.be.equal(0)
+
+        let depositAmount = ethers.utils.parseEther("4.000000000000000001")
+        await nativeOFTWithFee.deposit({ value: depositAmount })
+
+        expect(await nativeOFTWithFee.balanceOf(owner.address)).to.equal(depositAmount)
+        expect(await ethers.provider.getBalance(nativeOFTWithFee.address)).to.be.equal(depositAmount)
+
+        let leftOverAmount = ethers.utils.parseEther("0.000000000000000001")
+        let totalAmount = ethers.utils.parseEther("4.000000000000000001")
+        let minAmount = ethers.utils.parseEther("4.000000000000000000")
+        let totalAmountMinusDust = ethers.utils.parseEther("4")
+
+        // estimate nativeFees
+        let nativeFee = (await nativeOFTWithFee.estimateSendFee(remoteChainId, ownerAddressBytes32, totalAmount, false, "0x")).nativeFee
+        await nativeOFTWithFee.sendFrom(
+            owner.address,
+            remoteChainId, // destination chainId
+            ownerAddressBytes32, // destination address to send tokens to
+            totalAmount, // quantity of tokens to send (in units of wei)
+            minAmount, // quantity of tokens to send (in units of wei)
+            [owner.address, ethers.constants.AddressZero, "0x"],
+            { value: nativeFee.add(totalAmount.sub(depositAmount)) } // pass a msg.value to pay the LayerZero message fee
+        )
+
+        expect(await ethers.provider.getBalance(nativeOFTWithFee.address)).to.be.equal(totalAmount)
+        expect(await ethers.provider.getBalance(localEndpoint.address)).to.be.equal(nativeFee)
+        expect(await ethers.provider.getBalance(remoteEndpoint.address)).to.be.equal(ethers.utils.parseEther("0"))
+        expect(await nativeOFTWithFee.balanceOf(nativeOFTWithFee.address)).to.be.equal(totalAmountMinusDust)
+        expect(await nativeOFTWithFee.balanceOf(owner.address)).to.be.equal(leftOverAmount)
+        expect(await remoteOFTWithFee.balanceOf(owner.address)).to.be.equal(totalAmountMinusDust)
+    })
+
+    it("sendFrom() - from != sender with addition msg.value", async function () {
+        // ensure they're both allocated initial amounts
+        expect(await nativeOFTWithFee.balanceOf(owner.address)).to.equal(0)
+        expect(await remoteOFTWithFee.balanceOf(owner.address)).to.equal(0)
+        expect(await ethers.provider.getBalance(nativeOFTWithFee.address)).to.be.equal(0)
+
+        let depositAmount = ethers.utils.parseEther("3")
+        await nativeOFTWithFee.deposit({ value: depositAmount })
+
+        expect(await nativeOFTWithFee.balanceOf(owner.address)).to.equal(depositAmount)
+        expect(await ethers.provider.getBalance(nativeOFTWithFee.address)).to.be.equal(depositAmount)
+
+        let leftOverAmount = ethers.utils.parseEther("0")
+        let totalAmount = ethers.utils.parseEther("4")
+
+        // approve the other user to send the tokens
+        await nativeOFTWithFee.approve(alice.address, totalAmount)
+
+        // estimate nativeFees
+        let nativeFee = (await nativeOFTWithFee.estimateSendFee(remoteChainId, ownerAddressBytes32, totalAmount, false, "0x")).nativeFee
+        await nativeOFTWithFee.connect(alice).sendFrom(
+            owner.address,
+            remoteChainId, // destination chainId
+            ownerAddressBytes32, // destination address to send tokens to
+            totalAmount, // quantity of tokens to send (in units of wei)
+            totalAmount, // quantity of tokens to send (in units of wei)
+            [owner.address, ethers.constants.AddressZero, "0x"],
+            { value: nativeFee.add(totalAmount.sub(depositAmount)) } // pass a msg.value to pay the LayerZero message fee
+        )
+
+        expect(await ethers.provider.getBalance(nativeOFTWithFee.address)).to.be.equal(totalAmount)
+        expect(await ethers.provider.getBalance(localEndpoint.address)).to.be.equal(nativeFee)
+        expect(await ethers.provider.getBalance(remoteEndpoint.address)).to.be.equal(ethers.utils.parseEther("0"))
+        expect(await nativeOFTWithFee.balanceOf(nativeOFTWithFee.address)).to.be.equal(totalAmount)
+        expect(await nativeOFTWithFee.balanceOf(owner.address)).to.be.equal(leftOverAmount)
+        expect(await remoteOFTWithFee.balanceOf(owner.address)).to.be.equal(totalAmount)
+    })
+
+    it("sendFrom() - from != sender with not enough native", async function () {
+        await nativeOFTWithFee.setUseCustomAdapterParams(true)
+
+        // ensure they're both allocated initial amounts
+        expect(await nativeOFTWithFee.balanceOf(owner.address)).to.equal(0)
+        expect(await remoteOFTWithFee.balanceOf(owner.address)).to.equal(0)
+        expect(await ethers.provider.getBalance(nativeOFTWithFee.address)).to.be.equal(0)
+
+        let depositAmount = ethers.utils.parseEther("4")
+        await nativeOFTWithFee.deposit({ value: depositAmount })
+
+        expect(await nativeOFTWithFee.balanceOf(owner.address)).to.equal(depositAmount)
+        expect(await ethers.provider.getBalance(nativeOFTWithFee.address)).to.be.equal(depositAmount)
+
+        let totalAmount = ethers.utils.parseEther("5")
+
+        // approve the other user to send the tokens
+        await nativeOFTWithFee.approve(alice.address, totalAmount)
+
+        let messageFee = ethers.utils.parseEther("0.5") // conversion to units of wei
+        await nativeOFTWithFee.setUseCustomAdapterParams(false)
+        await remoteOFTWithFee.setUseCustomAdapterParams(false)
+        await expect(
+            nativeOFTWithFee.connect(alice).sendFrom(
+                owner.address,
+                remoteChainId, // destination chainId
+                ownerAddressBytes32, // destination address to send tokens to
+                totalAmount, // quantity of tokens to send (in units of wei)
+                totalAmount, // quantity of tokens to send (in units of wei)
+                [owner.address, ethers.constants.AddressZero, "0x"],
+                { value: messageFee } // pass a msg.value to pay the LayerZero message fee
+            )
+        ).to.be.revertedWith("NativeOFTWithFee: Insufficient msg.value")
+    })
+
+    it("sendFrom() - from != sender not approved expect revert", async function () {
+        await nativeOFTWithFee.setUseCustomAdapterParams(true)
+
+        // ensure they're both allocated initial amounts
+        expect(await nativeOFTWithFee.balanceOf(owner.address)).to.equal(0)
+        expect(await remoteOFTWithFee.balanceOf(owner.address)).to.equal(0)
+        expect(await ethers.provider.getBalance(nativeOFTWithFee.address)).to.be.equal(0)
+
+        let depositAmount = ethers.utils.parseEther("4")
+        await nativeOFTWithFee.deposit({ value: depositAmount })
+
+        expect(await nativeOFTWithFee.balanceOf(owner.address)).to.equal(depositAmount)
+        expect(await ethers.provider.getBalance(nativeOFTWithFee.address)).to.be.equal(depositAmount)
+
+        let totalAmount = ethers.utils.parseEther("4")
+
+        let messageFee = ethers.utils.parseEther("1") // conversion to units of wei
+        await nativeOFTWithFee.setUseCustomAdapterParams(false)
+        await remoteOFTWithFee.setUseCustomAdapterParams(false)
+        await expect(
+            nativeOFTWithFee.connect(alice).sendFrom(
+                owner.address,
+                remoteChainId, // destination chainId
+                ownerAddressBytes32, // destination address to send tokens to
+                totalAmount, // quantity of tokens to send (in units of wei)
+                totalAmount, // quantity of tokens to send (in units of wei)
+                [owner.address, ethers.constants.AddressZero, "0x"],
+                { value: messageFee } // pass a msg.value to pay the LayerZero message fee
+            )
+        ).to.be.revertedWith("ERC20: insufficient allowance")
+    })
+
+    it("sendFrom() - with insufficient value and expect revert", async function () {
+        await nativeOFTWithFee.setUseCustomAdapterParams(true)
+
+        // ensure they're both allocated initial amounts
+        expect(await nativeOFTWithFee.balanceOf(owner.address)).to.equal(0)
+        expect(await remoteOFTWithFee.balanceOf(owner.address)).to.equal(0)
+        expect(await ethers.provider.getBalance(nativeOFTWithFee.address)).to.be.equal(0)
+
+        let depositAmount = ethers.utils.parseEther("4")
+        await nativeOFTWithFee.deposit({ value: depositAmount })
+
+        expect(await nativeOFTWithFee.balanceOf(owner.address)).to.equal(depositAmount)
+        expect(await ethers.provider.getBalance(nativeOFTWithFee.address)).to.be.equal(depositAmount)
+
+        let totalAmount = ethers.utils.parseEther("8")
+        let messageFee = ethers.utils.parseEther("3") // conversion to units of wei
+        await nativeOFTWithFee.setUseCustomAdapterParams(false)
+        await remoteOFTWithFee.setUseCustomAdapterParams(false)
+        await expect(
+            nativeOFTWithFee.sendFrom(
+                owner.address,
+                remoteChainId, // destination chainId
+                ownerAddressBytes32, // destination address to send tokens to
+                totalAmount, // quantity of tokens to send (in units of wei)
+                totalAmount, // quantity of tokens to send (in units of wei)
+                [owner.address, ethers.constants.AddressZero, "0x"],
+                { value: messageFee } // pass a msg.value to pay the LayerZero message fee
+            )
+        ).to.be.revertedWith("NativeOFTWithFee: Insufficient msg.value")
+    })
+
+    it("sendFrom() - tokens from main to other chain using adapterParam", async function () {
+        await nativeOFTWithFee.setUseCustomAdapterParams(true)
+
+        // ensure they're both allocated initial amounts
+        expect(await nativeOFTWithFee.balanceOf(owner.address)).to.equal(0)
+        expect(await remoteOFTWithFee.balanceOf(owner.address)).to.equal(0)
+
+        const amount = ethers.utils.parseEther("100")
+        const messageFee = ethers.utils.parseEther("101") // conversion to units of wei
+        await nativeOFTWithFee.setMinDstGas(remoteChainId, parseInt(await nativeOFTWithFee.PT_SEND()), 225000)
+        const adapterParam = ethers.utils.solidityPack(["uint16", "uint256"], [1, 225000])
+        await nativeOFTWithFee.sendFrom(
+            owner.address,
+            remoteChainId, // destination chainId
+            ownerAddressBytes32, // destination address to send tokens to
+            amount, // quantity of tokens to send (in units of wei)
+            amount, // quantity of tokens to send (in units of wei)
+            [owner.address, ethers.constants.AddressZero, adapterParam],
+            { value: messageFee } // pass a msg.value to pay the LayerZero message fee
+        )
+
+        // verify tokens burned on source chain and minted on destination chain
+        expect(await nativeOFTWithFee.balanceOf(nativeOFTWithFee.address)).to.be.equal(amount)
+        expect(await remoteOFTWithFee.balanceOf(owner.address)).to.be.equal(amount)
+    })
+
+    it("setMinDstGas() - when type is not set on destination chain", async function () {
+        await nativeOFTWithFee.setUseCustomAdapterParams(true)
+        const amount = ethers.utils.parseEther("100")
+        const messageFee = ethers.utils.parseEther("101") // conversion to units of wei
+        const adapterParam = ethers.utils.solidityPack(["uint16", "uint256"], [1, 225000])
+        await expect(
+            nativeOFTWithFee.sendFrom(
+                owner.address,
+                remoteChainId, // destination chainId
+                ownerAddressBytes32, // destination address to send tokens to
+                amount, // quantity of tokens to send (in units of wei)
+                amount, // quantity of tokens to send (in units of wei)
+                [owner.address, ethers.constants.AddressZero, adapterParam],
+                { value: messageFee } // pass a msg.value to pay the LayerZero message fee
+            )
+        ).to.be.revertedWith("LzApp: minGasLimit not set")
+    })
+
+    it("setMinDstGas() - set min dst gas higher than what we are sending and expect revert", async function () {
+        await nativeOFTWithFee.setUseCustomAdapterParams(true)
+        const amount = ethers.utils.parseEther("100")
+        const messageFee = ethers.utils.parseEther("101") // conversion to units of wei
+        await nativeOFTWithFee.setMinDstGas(remoteChainId, parseInt(await nativeOFTWithFee.PT_SEND()), 250000)
+        const adapterParam = ethers.utils.solidityPack(["uint16", "uint256"], [1, 225000])
+        await expect(
+            nativeOFTWithFee.sendFrom(
+                owner.address,
+                remoteChainId, // destination chainId
+                ownerAddressBytes32, // destination address to send tokens to
+                amount, // quantity of tokens to send (in units of wei)
+                amount, // quantity of tokens to send (in units of wei)
+                [owner.address, ethers.constants.AddressZero, adapterParam],
+                { value: messageFee } // pass a msg.value to pay the LayerZero message fee
+            )
+        ).to.be.revertedWith("LzApp: gas limit is too low")
+    })
+
+    it("wrap() and unwrap()", async function () {
+        let ownerBalance = await ethers.provider.getBalance(owner.address)
+        expect(await ethers.provider.getBalance(nativeOFTWithFee.address)).to.equal(0)
+        expect(await nativeOFTWithFee.balanceOf(owner.address)).to.equal(0)
+
+        const amount = ethers.utils.parseEther("100.000000000000000001")
+        await nativeOFTWithFee.deposit({ value: amount })
+
+        let transFee = ownerBalance.sub(await ethers.provider.getBalance(owner.address)).sub(amount)
+
+        expect(await ethers.provider.getBalance(nativeOFTWithFee.address)).to.equal(amount)
+        expect(await ethers.provider.getBalance(owner.address)).to.equal(ownerBalance.sub(amount).sub(transFee))
+        expect(await nativeOFTWithFee.balanceOf(owner.address)).to.equal(amount)
+
+        await nativeOFTWithFee.withdraw(amount)
+        transFee = ownerBalance.sub(await ethers.provider.getBalance(owner.address))
+
+        expect(await ethers.provider.getBalance(nativeOFTWithFee.address)).to.equal(0)
+        expect(await ethers.provider.getBalance(owner.address)).to.equal(ownerBalance.sub(transFee))
+        expect(await nativeOFTWithFee.balanceOf(owner.address)).to.equal(0)
+    })
+
+    it("wrap() and unwrap() expect revert", async function () {
+        let ownerBalance = await ethers.provider.getBalance(owner.address)
+        expect(await ethers.provider.getBalance(nativeOFTWithFee.address)).to.equal(0)
+        expect(await nativeOFTWithFee.balanceOf(owner.address)).to.equal(0)
+
+        let amount = ethers.utils.parseEther("100")
+        await nativeOFTWithFee.deposit({ value: amount })
+
+        let transFee = ownerBalance.sub(await ethers.provider.getBalance(owner.address)).sub(amount)
+
+        expect(await ethers.provider.getBalance(nativeOFTWithFee.address)).to.equal(amount)
+        expect(await ethers.provider.getBalance(owner.address)).to.equal(ownerBalance.sub(amount).sub(transFee))
+        expect(await nativeOFTWithFee.balanceOf(owner.address)).to.equal(amount)
+
+        amount = ethers.utils.parseEther("150")
+        await expect(nativeOFTWithFee.withdraw(amount)).to.be.revertedWith("NativeOFTWithFee: Insufficient balance.")
+    })
+})


### PR DESCRIPTION
NativeOFTWithFee is Layer Zero’s example implementation of a cross-chain wrapped native token. On the source chain, where NativeOFTWithFee is deployed, users can: deposit the native tokens and receive NativeOFTWithFee at a 1:1 ratio, withdraw the native tokens back for NativeOFTWithFee at a 1:1 ratio, and send NativeOFTWithFee tokens to a different Layer Zero supported chain. This version allows for fees.