### PR TITLE
fix/rm_npmrc:  remove .npmrc as it is NPM_TOKEN is not needed

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
This file prevents normal developers from being able to build the code via invoking `yarn`.  Since not private packages are actually utilized, just remove the `.npmrc` file altogether.