### PR TITLE
fix OFT and OFTV2 deployment code and corresponding README.md instruc…

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ If the decimal point is 18, then uint64 can only represent approximately 18 toke
 
 ## OFTV2Mock.sol - an omnichain ERC20
 
-> :warning: **You must perform `setTrustedRemote()` (step 2). This is a mock deployment that auto mints tokens to `msg.sender`**
+:warning: **You must perform `setTrustedRemote()` (step 2). This is a mock deployment that auto mints tokens to `msg.sender`**
 
 1. Deploy two contracts:
 
 ```shell
-npx hardhat --network goerli deploy --tags OFTV2Mock
-npx hardhat --network fuji deploy --tags OFTV2Mock
+npx hardhat --network goerli deploy --tags ExampleOFTV2
+npx hardhat --network fuji deploy --tags ExampleOFTV2
 ```
 
 2. Set the "trusted remotes" (ie: your contracts) so each of them can receive messages from one another, and `only` one another.
@@ -56,7 +56,16 @@ npx hardhat --network goerli setTrustedRemote --target-network fuji --contract O
 npx hardhat --network fuji setTrustedRemote --target-network goerli --contract OFTV2Mock
 ```
 
-3. Send tokens from goerli to fuji
+3. Set the "minDstGas" required on the destination chain.
+
+```shell
+npx hardhat --network goerli setMinDstGas --packet-type 0 --target-network fuji --contract OFTV2Mock --min-gas 100000
+npx hardhat --network fuji setMinDstGas --packet-type 0 --target-network goerli --contract OFTV2Mock --min-gas 100000
+```
+
+:warning: Although `100000` is used for `min-gas` in this example, you should set this value based on careful gas consumption analysis.
+
+4. Send tokens from goerli to fuji
 
 ```shell
 npx hardhat --network goerli oftv2Send --target-network fuji --qty 42 --contract OFTV2Mock
@@ -71,13 +80,13 @@ Check the `ONFT_ARGS` constant defined in ONFT721 deploy script for the specific
 
 ## ONFT721Mock.sol 
 
-> :warning: **You must perform the `setTrustedRemote()` (step 2).**
+:warning: **You must perform the `setTrustedRemote()` (step 2).**
 
 1. Deploy two contracts:
 
 ```shell
- npx hardhat --network bsc-testnet deploy --tags ONFT721Mock
- npx hardhat --network fuji deploy --tags ONFT721Mock
+npx hardhat --network bsc-testnet deploy --tags ONFT721
+npx hardhat --network fuji deploy --tags ONFT721
 ```
 
 2. Set the "trusted remotes", so each contract can send & receive messages from one another, and **only** one another.

--- a/deploy/ExampleOFT.js
+++ b/deploy/ExampleOFT.js
@@ -10,7 +10,7 @@ module.exports = async function ({ deployments, getNamedAccounts }) {
     const endpointAddr = LZ_ENDPOINTS[hre.network.name]
     console.log(`[${hre.network.name}] LayerZero Endpoint address: ${endpointAddr}`)
 
-    await deploy("ExampleOFT", {
+    await deploy("OFTMock", {
         from: deployer,
         args: [endpointAddr],
         log: true,

--- a/deploy/ExampleOFTV2.js
+++ b/deploy/ExampleOFTV2.js
@@ -11,7 +11,7 @@ module.exports = async function ({ deployments, getNamedAccounts }) {
     const globalSupply = ethers.utils.parseUnits("1000000", 18)
     const sharedDecimals = 6
 
-    await deploy("ExampleOFTV2", {
+    await deploy("OFTV2Mock", {
         from: deployer,
         args: [lzEndpointAddress, globalSupply, sharedDecimals],
         log: true,

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -96,6 +96,11 @@ task(
     .addOptionalParam("contract", "If both contracts are the same name")
 
 //
+task("oftMint", "mint tokens", require("./oftMint"))
+    .addParam("toAddress", "address to mint to")
+    .addParam("qty", "qty of tokens to mint")
+
+//
 task("oftSend", "send tokens to another chain", require("./oftSend"))
     .addParam("qty", "qty of tokens to send")
     .addParam("targetNetwork", "the target network to let this instance receive messages from")

--- a/tasks/oftMint.js
+++ b/tasks/oftMint.js
@@ -1,0 +1,12 @@
+module.exports = async function (taskArgs, hre) {
+    let owner = (await ethers.getSigners())[0]
+    let toAddress = owner.address
+    let qty = ethers.utils.parseEther(taskArgs.qty)
+
+    const oftMock = await ethers.getContract("OFTMock")
+
+    let tx = await (
+        await oftMock.mintTokens(toAddress, qty)
+    ).wait()
+    console.log(`✅ OFT minted [${hre.network.name}] to: [${toAddress}] qty: [${qty}]`)
+}

--- a/tasks/oftv2Send.js
+++ b/tasks/oftv2Send.js
@@ -41,7 +41,11 @@ module.exports = async function (taskArgs, hre) {
             remoteChainId, // remote LayerZero chainId
             toAddressBytes, // 'to' address to send tokens
             qty, // amount of tokens to send (in wei)
-            [owner.address, ethers.constants.AddressZero, "0x"],
+            {
+                refundAddress: owner.address,
+                zroPaymentAddress: ethers.constants.AddressZero,
+                adapterParams,
+            },
             { value: fees[0] }
         )
     ).wait()


### PR DESCRIPTION
…tions

The instructions for deploying OFTV2 in README.md did not work, as the deployment scripts refer to ExampleOFT and ExampleOFTV2 contracts, which don't exist.  I changed these to OFTMock and OFTV2Mock respectively.  Additionally, instructions failed to mention that the deployer *must* set a minDstGasLimit in this version of code.  I added this instruction in and was able to send tokens successfully.

Lastly, even though there is not an example for OFT, we failed to include a task to mintTokens(...). This PR includes a small task to mint tokens so the OFT example can be tested.