### PR TITLE
Updated OFTCoreV2 for convenient use of the address format bytes32.

### DIFF
--- a/contracts/token/oft/v2/OFTCoreV2.sol
+++ b/contracts/token/oft/v2/OFTCoreV2.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.0;
 
 import "../../../lzApp/NonblockingLzApp.sol";
-import "../../../libraries/ExcessivelySafeCall.sol";
+//import "../../../libraries/ExcessivelySafeCall.sol"; already imported in NonblockingLzApp
 import "./interfaces/ICommonOFT.sol";
 import "./interfaces/IOFTReceiverV2.sol";
 
@@ -248,7 +248,7 @@ abstract contract OFTCoreV2 is NonblockingLzApp {
     function _decodeSendPayload(bytes memory _payload) internal view virtual returns (address to, uint64 amountSD) {
         require(_payload.toUint8(0) == PT_SEND && _payload.length == 41, "OFTCore: invalid payload");
 
-        to = _payload.toAddress(13); // drop the first 12 bytes of bytes32
+        to = _payload.toAddress(1); // drop the first 1 bytes of _payload to get address  
         amountSD = _payload.toUint64(33);
     }
 


### PR DESCRIPTION
Hello, I've been working with OFTV2 and noticed that during payload decoding in the _decodeSendPayload function to retrieve the 'to' address using the toAddress method, you were dropping the first 12 bytes of bytes32. Typically, when converting a bytes20 address to bytes32, we pad with zeros at the end rather than the beginning. Therefore, I made a correction for more convenient use. Additionally, in the OFTCoreV2 contract, ExcessivelySafeCall is imported, but it seems unnecessary since this library is already imported in the inherited NonblockingLzApp contract.