### PR TITLE
Ownable constructor fix regarding the OpenZeppelin V5 update

### DIFF
--- a/contracts/lzApp/LzApp.sol
+++ b/contracts/lzApp/LzApp.sol
@@ -28,7 +28,7 @@ abstract contract LzApp is Ownable, ILayerZeroReceiver, ILayerZeroUserApplicatio
     event SetTrustedRemoteAddress(uint16 _remoteChainId, bytes _remoteAddress);
     event SetMinDstGas(uint16 _dstChainId, uint16 _type, uint _minDstGas);
 
-    constructor(address _endpoint) {
+    constructor(address _endpoint) Ownable(_msgSender()){
         lzEndpoint = ILayerZeroEndpoint(_endpoint);
     }
 

--- a/contracts/token/oft/v1/NativeOFT.sol
+++ b/contracts/token/oft/v1/NativeOFT.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "./OFT.sol";
 
 contract NativeOFT is OFT, ReentrancyGuard {

--- a/contracts/token/oft/v2/NativeOFTV2.sol
+++ b/contracts/token/oft/v2/NativeOFTV2.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "./OFTV2.sol";
 
 contract NativeOFTV2 is OFTV2, ReentrancyGuard {

--- a/contracts/token/oft/v2/fee/Fee.sol
+++ b/contracts/token/oft/v2/fee/Fee.sol
@@ -20,7 +20,7 @@ abstract contract Fee is Ownable {
     event SetDefaultFeeBp(uint16 feeBp);
     event SetFeeOwner(address feeOwner);
 
-    constructor(){
+    constructor() Ownable(_msgSender()){
         feeOwner = owner();
     }
 

--- a/contracts/token/oft/v2/fee/NativeOFTWithFee.sol
+++ b/contracts/token/oft/v2/fee/NativeOFTWithFee.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "./OFTWithFee.sol";
 
 contract NativeOFTWithFee is OFTWithFee, ReentrancyGuard {

--- a/contracts/token/onft721/ONFT721Core.sol
+++ b/contracts/token/onft721/ONFT721Core.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.0;
 import "./interfaces/IONFT721Core.sol";
 import "../../lzApp/NonblockingLzApp.sol";
 import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
 abstract contract ONFT721Core is NonblockingLzApp, ERC165, ReentrancyGuard, IONFT721Core {
     uint16 public constant FUNCTION_TYPE_SEND = 1;


### PR DESCRIPTION
This is a fix that updates the LayerZero/solidity-examples code to be compatible to the OpenZeppelin V5 update regarding the Ownable class inheritance. I also recommend the creation of a new tag/release for the repository to help Brownie/Python frontend developers to import LayerZero's library in a more quicker and efficient way (brownie doesn't accept importing libraries without versioning/tag).