### PR TITLE
fix: update setTrustedRemote to setTrustedRemoteAddress

### DIFF
--- a/tasks/pingPongSetTrustedRemote.js
+++ b/tasks/pingPongSetTrustedRemote.js
@@ -8,7 +8,7 @@ module.exports = async function (taskArgs, hre) {
     const pingPong = await ethers.getContract("PingPong")
     console.log(`[source] pingPong.address: ${pingPong.address}`)
 
-    let tx = await (await pingPong.setTrustedRemote(dstChainId, dstPingPongAddr)).wait()
+    let tx = await (await pingPong.setTrustedRemoteAddress(dstChainId, dstPingPongAddr)).wait()
     console.log(`✅ [${hre.network.name}] PingPong.setTrustedRemote( ${dstChainId}, ${dstPingPongAddr} )`)
     console.log(`...tx: ${tx.transactionHash}`)
 }


### PR DESCRIPTION
- Update `pingPongSetTrustedRemote` task to use `setTrustedRemoteAddress` instead of `setTrustedRemote`
- Can be accessed using `npx hardhat --network  bsc-testnet pingPongSetTrustedRemote --target-network fuji` without providing path like `setTrustedRemote`