### PR TITLE
change IOFTV2 to IBaseOFTV2 and add a new implementation of IOFTV2

### DIFF
--- a/contracts/token/oft/v2/BaseOFTV2.sol
+++ b/contracts/token/oft/v2/BaseOFTV2.sol
@@ -3,10 +3,10 @@
 pragma solidity ^0.8.0;
 
 import "./OFTCoreV2.sol";
-import "./interfaces/IOFTV2.sol";
+import "./interfaces/IBaseOFTV2.sol";
 import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-abstract contract BaseOFTV2 is OFTCoreV2, ERC165, IOFTV2 {
+abstract contract BaseOFTV2 is OFTCoreV2, ERC165, IBaseOFTV2 {
     constructor(uint8 _sharedDecimals, address _lzEndpoint) OFTCoreV2(_sharedDecimals, _lzEndpoint) {}
 
     /************************************************************************
@@ -48,7 +48,7 @@ abstract contract BaseOFTV2 is OFTCoreV2, ERC165, IOFTV2 {
      * public view functions
      ************************************************************************/
     function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165, IERC165) returns (bool) {
-        return interfaceId == type(IOFTV2).interfaceId || super.supportsInterface(interfaceId);
+        return interfaceId == type(IBaseOFTV2).interfaceId || super.supportsInterface(interfaceId);
     }
 
     function estimateSendFee(

--- a/contracts/token/oft/v2/interfaces/IBaseOFTV2.sol
+++ b/contracts/token/oft/v2/interfaces/IBaseOFTV2.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.5.0;
+
+import "./ICommonOFT.sol";
+
+/**
+ * @dev Interface of the BaseIOFT core standard
+ */
+interface IBaseOFTV2 is ICommonOFT {
+
+    /**
+     * @dev send `_amount` amount of token to (`_dstChainId`, `_toAddress`) from `_from`
+     * `_from` the owner of token
+     * `_dstChainId` the destination chain identifier
+     * `_toAddress` can be any size depending on the `dstChainId`.
+     * `_amount` the quantity of tokens in wei
+     * `_refundAddress` the address LayerZero refunds if too much message fee is sent
+     * `_zroPaymentAddress` set to address(0x0) if not paying in ZRO (LayerZero Token)
+     * `_adapterParams` is a flexible bytes array to indicate messaging adapter services
+     */
+    function sendFrom(address _from, uint16 _dstChainId, bytes32 _toAddress, uint _amount, LzCallParams calldata _callParams) external payable;
+
+    function sendAndCall(address _from, uint16 _dstChainId, bytes32 _toAddress, uint _amount, bytes calldata _payload, uint64 _dstGasForCall, LzCallParams calldata _callParams) external payable;
+}

--- a/contracts/token/oft/v2/interfaces/IBaseOFTV2.sol
+++ b/contracts/token/oft/v2/interfaces/IBaseOFTV2.sol
@@ -11,13 +11,13 @@ interface IBaseOFTV2 is ICommonOFT {
 
     /**
      * @dev send `_amount` amount of token to (`_dstChainId`, `_toAddress`) from `_from`
-     * `_from` the owner of token
-     * `_dstChainId` the destination chain identifier
-     * `_toAddress` can be any size depending on the `dstChainId`.
-     * `_amount` the quantity of tokens in wei
-     * `_refundAddress` the address LayerZero refunds if too much message fee is sent
-     * `_zroPaymentAddress` set to address(0x0) if not paying in ZRO (LayerZero Token)
-     * `_adapterParams` is a flexible bytes array to indicate messaging adapter services
+     * @param _from The owner of token
+     * @param _dstChainId The destination chain identifier
+     * @param _toAddress The address of receiver. It can be any size depending on the `dstChainId`.
+     * @param _amount The quantity of tokens in wei
+     * @param _refundAddress The address LayerZero refunds if too much message fee is sent
+     * @param _zroPaymentAddress The address for zro payment. Set to address(0x0) if not paying in ZRO (LayerZero Token)
+     * @param _adapterParams Flexible bytes array to indicate messaging adapter services
      */
     function sendFrom(address _from, uint16 _dstChainId, bytes32 _toAddress, uint _amount, LzCallParams calldata _callParams) external payable;
 

--- a/contracts/token/oft/v2/interfaces/IOFTV2.sol
+++ b/contracts/token/oft/v2/interfaces/IOFTV2.sol
@@ -2,24 +2,10 @@
 
 pragma solidity >=0.5.0;
 
-import "./ICommonOFT.sol";
+import "./IBaseOFTV2.sol";
+import "@openzeppelin/contracts/interfaces/IERC20.sol";
 
 /**
  * @dev Interface of the IOFT core standard
  */
-interface IOFTV2 is ICommonOFT {
-
-    /**
-     * @dev send `_amount` amount of token to (`_dstChainId`, `_toAddress`) from `_from`
-     * `_from` the owner of token
-     * `_dstChainId` the destination chain identifier
-     * `_toAddress` can be any size depending on the `dstChainId`.
-     * `_amount` the quantity of tokens in wei
-     * `_refundAddress` the address LayerZero refunds if too much message fee is sent
-     * `_zroPaymentAddress` set to address(0x0) if not paying in ZRO (LayerZero Token)
-     * `_adapterParams` is a flexible bytes array to indicate messaging adapter services
-     */
-    function sendFrom(address _from, uint16 _dstChainId, bytes32 _toAddress, uint _amount, LzCallParams calldata _callParams) external payable;
-
-    function sendAndCall(address _from, uint16 _dstChainId, bytes32 _toAddress, uint _amount, bytes calldata _payload, uint64 _dstGasForCall, LzCallParams calldata _callParams) external payable;
-}
+interface IOFTV2 is IBaseOFTV2, IERC20 {}

--- a/contracts/token/oft/v2/mocks/OFTStakingMockV2.sol
+++ b/contracts/token/oft/v2/mocks/OFTStakingMockV2.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "../interfaces/IOFTV2.sol";
+import "../interfaces/IBaseOFTV2.sol";
 import "../interfaces/IOFTReceiverV2.sol";
 import "../../../../libraries/BytesLib.sol";
 
@@ -21,7 +21,7 @@ contract OFTStakingMockV2 is IOFTReceiverV2 {
     // ... other types
 
     // variables
-    IOFTV2 public oft;
+    IBaseOFTV2 public oft;
     mapping(uint16 => bytes32) public remoteStakingContracts;
     mapping(address => uint) public balances;
     bool public paused; // for testing try/catch
@@ -32,7 +32,7 @@ contract OFTStakingMockV2 is IOFTReceiverV2 {
 
     // _oft can be any composable OFT contract, e.g. ComposableOFT, ComposableBasedOFT and ComposableProxyOFT.
     constructor(address _oft) {
-        oft = IOFTV2(_oft);
+        oft = IBaseOFTV2(_oft);
         IERC20(oft.token()).safeApprove(_oft, type(uint).max);
     }
 


### PR DESCRIPTION
I found the IOFTV2 interface naming misleading, as it seemed to be the interface for the OFTV2 contract. However, It is the interface for the BaseOFTV2 contract. I have renamed IOFTV2 -> IBaseOFTV2, and have created a new interface for the OFTV2 contract called IOFTV2.

Please let me know if any new tests need to be added or if there is a better way to go about this considering backwards compatibility. 